### PR TITLE
Sw 3573 Fetch and Cache secrets from AWS Secrets Manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: localstack
           DEFAULT_REGION: eu-west-1
           AWS_ELASTICSEARCH_ENDPOINT: http://localhost:4571
-          SECRETS_MANAGER_ENDPOINT: http://localhost:4566
+          AWS_SECRETS_MANAGER_ENDPOINT: http://localhost:4566
       - image: localstack/localstack-full:0.12.8
         environment:
           DEFAULT_REGION: eu-west-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,13 @@ jobs:
           GOTESTSUM_FORMAT: short-verbose
           AWS_ACCESS_KEY_ID: localstack
           AWS_SECRET_ACCESS_KEY: localstack
+          DEFAULT_REGION: eu-west-1
           AWS_ELASTICSEARCH_ENDPOINT: http://localhost:4571
+          SECRETS_MANAGER_ENDPOINT: http://localhost:4566
       - image: localstack/localstack-full:0.12.8
         environment:
           DEFAULT_REGION: eu-west-1
-          SERVICES: es
+          SERVICES: es,secretsmanager
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ Another gotcha... Make sure annotations are written with 2 space tabs in order f
 
 ## Environment Variables
 
-| Variable                   | Default                           |  Description   |
-| -------------------------- | --------------------------------- | -------------- |
-| AWS_ELASTICSEARCH_ENDPOINT |                                   | Used for overwriting the ElasticSearch endpoint locally e.g. http://localstack:4571 |
-| AWS_REGION                 | eu-west-1                         | Set the AWS region for all operations with the SDK                                  |
-| AWS_ACCESS_KEY_ID          |                                   | Used for authenticating with localstack e.g. set to "localstack"                    |
-| AWS_SECRET_ACCESS_KEY      |                                   | Used for authenticating with localstack e.g. set to "localstack"                    |
-| PATH_PREFIX                |                                   | Path prefix where all requested will be routed                                      |
+| Variable                      | Default                           |  Description   |
+| ----------------------------- | --------------------------------- | -------------- |
+| AWS_ELASTICSEARCH_ENDPOINT    |                                   | Used for overwriting the ElasticSearch endpoint locally e.g. http://localstack:4571 |
+| AWS_REGION                    | eu-west-1                         | Set the AWS region for all operations with the SDK                                  |
+| AWS_ACCESS_KEY_ID             |                                   | Used for authenticating with localstack e.g. set to "localstack"                    |
+| AWS_SECRET_ACCESS_KEY         |                                   | Used for authenticating with localstack e.g. set to "localstack"                    |
+| AWS_SECRETS_MANAGER_ENDPOINT  |                                   | Used for accessing the Secrets Manager endpoint locally e.g. http://localstack:4566 |
+| ENVIRONMENT                   |                                   | Used when creating a new secrets cache object locally                               |
+| PATH_PREFIX                   |                                   | Path prefix where all requested will be routed                                      |

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -29,8 +29,7 @@ func applyAwsConfig (c *secretcache.Cache) {
 
 	sess, err := session.NewSession(&aws.Config{Region: &region})
 	if err != nil {
-		log.Fatal("Session failed to be created", err)
-		//errors.New("Session failed to be created" + err.Error())
+		log.Fatal("session failed to be created", err)
 	}
 
 	if iamRole, ok := os.LookupEnv("AWS_IAM_ROLE"); ok {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -13,7 +12,11 @@ import (
 
 type SecretsCache struct {
 	env string
-	cache *secretcache.Cache
+	cache AwsSecretsCache
+}
+
+type AwsSecretsCache interface {
+	GetSecretString(secretId string) (string, error)
 }
 
 func applyAwsConfig (c *secretcache.Cache) {
@@ -26,7 +29,8 @@ func applyAwsConfig (c *secretcache.Cache) {
 
 	sess, err := session.NewSession(&aws.Config{Region: &region})
 	if err != nil {
-		log.Println("session failed to be created", err)
+		log.Fatal("Session failed to be created", err)
+		//errors.New("Session failed to be created" + err.Error())
 	}
 
 	if iamRole, ok := os.LookupEnv("AWS_IAM_ROLE"); ok {
@@ -46,8 +50,5 @@ func New() *SecretsCache {
 }
 
 func (c *SecretsCache) GetSecretString(key string) (string, error) {
-	resp, err:= c.cache.GetSecretString(c.env + "/" + key)
-	fmt.Println(fmt.Sprintf("%#v", resp))
-	fmt.Println(fmt.Sprintf("%#v", err))
 	return c.cache.GetSecretString(c.env + "/" + key)
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"log"
+	"os"
+)
+
+type SecretsCache struct {
+	env string
+	cache *secretcache.Cache
+}
+
+func applyAwsConfig (c *secretcache.Cache) {
+
+	var region string
+	var ok bool
+	if region, ok = os.LookupEnv("AWS_REGION"); !ok {
+		region = "eu-west-1"
+	}
+
+	sess, err := session.NewSession(&aws.Config{Region: &region})
+	if err != nil {
+		log.Println("session failed to be created", err)
+	}
+
+	if iamRole, ok := os.LookupEnv("AWS_IAM_ROLE"); ok {
+		c := stscreds.NewCredentials(sess, iamRole)
+		sess.Config.Credentials = c
+	}
+
+	endpoint := os.Getenv("SECRETS_MANAGER_ENDPOINT")
+	sess.Config.Endpoint = &endpoint
+	c.Client = secretsmanager.New(sess)
+}
+
+func New() *SecretsCache {
+	env := os.Getenv("ENVIRONMENT")
+	cache, _ := secretcache.New(applyAwsConfig)
+	return &SecretsCache{env, cache}
+}
+
+func (c *SecretsCache) GetSecretString(key string) (string, error) {
+	resp, err:= c.cache.GetSecretString(c.env + "/" + key)
+	fmt.Println(fmt.Sprintf("%#v", resp))
+	fmt.Println(fmt.Sprintf("%#v", err))
+	return c.cache.GetSecretString(c.env + "/" + key)
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -37,7 +37,7 @@ func applyAwsConfig (c *secretcache.Cache) {
 		sess.Config.Credentials = c
 	}
 
-	endpoint := os.Getenv("SECRETS_MANAGER_ENDPOINT")
+	endpoint := os.Getenv("AWS_SECRETS_MANAGER_ENDPOINT")
 	sess.Config.Endpoint = &endpoint
 	c.Client = secretsmanager.New(sess)
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -107,11 +107,11 @@ func TestApplyAwsConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		oldEndpoint := os.Getenv("SECRETS_MANAGER_ENDPOINT")
+		oldEndpoint := os.Getenv("AWS_SECRETS_MANAGER_ENDPOINT")
 		oldRegion := os.Getenv("AWS_REGION")
 		oldIamRole := os.Getenv("AWS_IAM_ROLE")
 
-		_ = os.Setenv("SECRETS_MANAGER_ENDPOINT", test.endpoint)
+		_ = os.Setenv("AWS_SECRETS_MANAGER_ENDPOINT", test.endpoint)
 		if test.region == "" {
 			_ = os.Unsetenv("AWS_REGION")
 		} else {
@@ -132,7 +132,7 @@ func TestApplyAwsConfig(t *testing.T) {
 		assert.Equal(t, "https://"+test.endpoint, cl.Endpoint, test.scenario)
 		assert.Equal(t, test.wantRegion, *cl.Config.Region, test.scenario)
 
-		_ = os.Setenv("SECRETS_MANAGER_ENDPOINT", oldEndpoint)
+		_ = os.Setenv("AWS_SECRETS_MANAGER_ENDPOINT", oldEndpoint)
 		_ = os.Setenv("AWS_REGION", oldRegion)
 
 		if oldIamRole == "" {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -83,7 +83,6 @@ func TestApplyAwsConfig(t *testing.T) {
 		region     string
 		wantRegion string
 		role       string
-		wantErr    bool
 	}{
 		{
 			scenario:   "Blank AWS region",

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,148 @@
+package cache
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"os"
+	"testing"
+)
+
+type MockAwsSecretsCache struct {
+	mock.Mock
+}
+
+func (m *MockAwsSecretsCache) GetSecretString(secretId string) (string, error) {
+	args := m.Called(secretId)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func TestNew(t *testing.T) {
+	oldEnv := os.Getenv("ENVIRONMENT")
+	_ = os.Setenv("ENVIRONMENT", "test_env")
+
+	sc := New()
+	assert.IsType(t, new(SecretsCache), sc)
+	assert.Equal(t, "test_env", sc.env)
+	assert.IsType(t, new(secretcache.Cache), sc.cache)
+
+	_ = os.Setenv("ENVIRONMENT", oldEnv)
+}
+
+func TestSecretsCache_GetSecretString(t *testing.T) {
+	tests := []struct {
+		scenario       string
+		env            string
+		secretKey      string
+		returnedSecret string
+		returnedErr    error
+	}{
+		{
+			scenario:       "Secret retrieved successfully",
+			env:            "test_env",
+			secretKey:      "test_key",
+			returnedSecret: "test_secret",
+			returnedErr:    nil,
+		},
+		{
+			scenario:       "AwsSecretsCache returns an error",
+			env:            "test_env",
+			secretKey:      "test_key",
+			returnedSecret: "",
+			returnedErr:    errors.New("test error"),
+		},
+		{
+			scenario:       "No ENVIRONMENT defined",
+			env:            "",
+			secretKey:      "test_key",
+			returnedSecret: "",
+			returnedErr:    errors.New("test error"),
+		},
+	}
+	for _, test := range tests {
+		msc := new(MockAwsSecretsCache)
+		msc.On("GetSecretString", test.env + "/" + test.secretKey).Return(test.returnedSecret, test.returnedErr).Times(1)
+
+		sc := SecretsCache{
+			env:   test.env,
+			cache: msc,
+		}
+		secret, err := sc.GetSecretString(test.secretKey)
+
+		assert.Equal(t, test.returnedSecret, secret, test.scenario)
+		assert.Equal(t, test.returnedErr, err, test.scenario)
+	}
+}
+
+func TestApplyAwsConfig(t *testing.T) {
+	tests := []struct {
+		scenario   string
+		endpoint   string
+		region     string
+		wantRegion string
+		role       string
+		wantErr    bool
+	}{
+		{
+			scenario:   "Blank AWS region",
+			endpoint:   "test-endpoint",
+			region:     "",
+			wantRegion: "eu-west-1",
+			role:       "test-role",
+		},
+		{
+			scenario:   "Custom AWS region",
+			endpoint:   "test-endpoint",
+			region:     "test-region",
+			wantRegion: "test-region",
+			role:       "test-role",
+		},
+		{
+			scenario:   "Blank Iam Role",
+			endpoint:   "test-endpoint",
+			region:     "test-region",
+			wantRegion: "test-region",
+			role:       "",
+		},
+	}
+	for _, test := range tests {
+		oldEndpoint := os.Getenv("SECRETS_MANAGER_ENDPOINT")
+		oldRegion := os.Getenv("AWS_REGION")
+		oldIamRole := os.Getenv("AWS_IAM_ROLE")
+
+		_ = os.Setenv("SECRETS_MANAGER_ENDPOINT", test.endpoint)
+		if test.region == "" {
+			_ = os.Unsetenv("AWS_REGION")
+		} else {
+			_ = os.Setenv("AWS_REGION", test.region)
+		}
+		if test.role == "" {
+			_ = os.Unsetenv("AWS_IAM_ROLE")
+		} else {
+			_ = os.Setenv("AWS_IAM_ROLE", test.role)
+		}
+
+		c := new(secretcache.Cache)
+
+		applyAwsConfig(c)
+
+		cl := c.Client.(*secretsmanager.SecretsManager)
+
+		assert.Equal(t, "https://"+test.endpoint, cl.Endpoint, test.scenario)
+		assert.Equal(t, test.wantRegion, *cl.Config.Region, test.scenario)
+
+		_ = os.Setenv("SECRETS_MANAGER_ENDPOINT", oldEndpoint)
+		_ = os.Setenv("AWS_REGION", oldRegion)
+
+		if oldIamRole == "" {
+			_ = os.Unsetenv("AWS_IAM_ROLE")
+		} else {
+			_ = os.Setenv("AWS_IAM_ROLE", oldIamRole)
+		}
+	}
+}
+
+
+

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -2,5 +2,5 @@ AWS_ACCESS_KEY_ID=localstack
 AWS_SECRET_ACCESS_KEY=localstack
 AWS_ELASTICSEARCH_ENDPOINT=http://localstack:4571
 PATH_PREFIX=/services/search-service
-JWT_SECRET=MyTestSecret
-USER_HASH_SALT=ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0
+SECRETS_MANAGER_ENDPOINT=http://localstack:4566
+ENVIRONMENT=local

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,6 +1,6 @@
 AWS_ACCESS_KEY_ID=localstack
 AWS_SECRET_ACCESS_KEY=localstack
 AWS_ELASTICSEARCH_ENDPOINT=http://localstack:4571
+AWS_SECRETS_MANAGER_ENDPOINT=http://localstack:4566
 PATH_PREFIX=/services/search-service
-SECRETS_MANAGER_ENDPOINT=http://localstack:4566
 ENVIRONMENT=local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     environment:
       DEFAULT_REGION: eu-west-1
       HOSTNAME_EXTERNAL: localstack
-      SERVICES: es
+      SERVICES: es, secretsmanager
+    ports:
+      - 4571:4571
     volumes:
       - "./scripts/localstack:/docker-entrypoint-initaws.d"
   swagger-ui:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       DEFAULT_REGION: eu-west-1
       HOSTNAME_EXTERNAL: localstack
       SERVICES: es, secretsmanager
-    ports:
-      - 4571:4571
     volumes:
       - "./scripts/localstack:/docker-entrypoint-initaws.d"
   swagger-ui:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.7
+	github.com/aws/aws-secretsmanager-caching-go v1.1.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
+github.com/aws/aws-sdk-go v1.19.23/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.38.7 h1:uOu2IrTiNhcSNAjBmA21t48lTx5mgGdcFKamDjXMscA=
 github.com/aws/aws-sdk-go v1.38.7/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-secretsmanager-caching-go v1.1.0 h1:vcV94XGJ9KouXKYBTMqgrBw96Tae8JKLmoUZ5SbaXNo=
+github.com/aws/aws-secretsmanager-caching-go v1.1.0/go.mod h1:wahQpJP1dZKMqjGFAjGCqilHkTlN0zReGWocPLbXmxg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -7,6 +10,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"opg-search-service/cache"
 	"opg-search-service/middleware"
 	"opg-search-service/person"
 	"os"
@@ -35,12 +36,13 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	secretsCache := cache.New()
+
 	// Create a sub-router for protected handlers
 	postRouter := sm.Methods(http.MethodPost).Subrouter()
-	postRouter.Use(middleware.JwtVerify)
+	postRouter.Use(middleware.JwtVerify(secretsCache))
 
 	// Register protected handlers
-
 	iph, err := person.NewIndexHandler(l)
 	if err != nil {
 		l.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/suite"
 	"log"
 	"net"
 	"net/http"
@@ -13,8 +14,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/suite"
 )
 
 type EndToEndTestSuite struct {
@@ -27,9 +26,10 @@ type EndToEndTestSuite struct {
 func (suite *EndToEndTestSuite) SetupSuite() {
 	os.Setenv("JWT_SECRET", "MyTestSecret")
 	os.Setenv("USER_HASH_SALT", "ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0")
+	os.Setenv("ENVIRONMENT", "local")
 
 	logBuf := new(bytes.Buffer)
-	logger := log.New(logBuf, "opg-file-service ", log.LstdFlags)
+	logger := log.New(logBuf, "opg-search-service ", log.LstdFlags)
 	httpClient := &http.Client{}
 	suite.esClient, _ = elasticsearch.NewClient(httpClient, logger)
 

--- a/middleware/jwt_auth.go
+++ b/middleware/jwt_auth.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"opg-search-service/response"
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
@@ -29,13 +29,8 @@ func JwtVerify(secretsCache Cacheable) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			jwtSecret, jwtErr := secretsCache.GetSecretString("jwt-key")
 			if jwtErr != nil {
-				rw.WriteHeader(http.StatusInternalServerError)
-				if err := json.NewEncoder(rw).Encode(&authorisationError{
-					Error:			"missing_secret_key",
-					Description: 	jwtErr.Error(),
-				}); err != nil {
-					log.Println("handler/middleware failed to write response:", err)
-				}
+				log.Println("Error in fetching JWT secret from cache:", jwtErr.Error())
+				response.WriteJSONError(rw, "missing_secret_key", jwtErr.Error(), http.StatusInternalServerError)
 				return
 			}
 
@@ -44,22 +39,15 @@ func JwtVerify(secretsCache Cacheable) func(next http.Handler) http.Handler {
 			token, authErr := verifyToken(header, jwtSecret)
 
 			if authErr != nil {
-				rw.WriteHeader(http.StatusUnauthorized)
-				if err := json.NewEncoder(rw).Encode(authErr); err != nil {
-					log.Println("handler/middleware failed to write response:", err)
-				}
+				log.Println("Error in token verification :", authErr.Description)
+				response.WriteJSONError(rw, "Authorisation Error", authErr.Error, http.StatusUnauthorized)
 			} else {
 				claims := token.Claims.(jwt.MapClaims)
 				email := claims["session-data"].(string)
 				salt, saltErr := secretsCache.GetSecretString("user-hash-salt")
 				if saltErr != nil {
-					rw.WriteHeader(http.StatusInternalServerError)
-					if err := json.NewEncoder(rw).Encode(&authorisationError{
-						Error:			"missing_secret_salt",
-						Description: 	saltErr.Error(),
-					}); err != nil {
-						log.Println("handler/middleware failed to write response:", err)
-					}
+					log.Println("Error in fetching hash salt from cache:", saltErr.Error())
+					response.WriteJSONError(rw, "missing_secret_salt", saltErr.Error(), http.StatusInternalServerError)
 					return
 				}
 				hashedEmail := hashEmail(email, salt)

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -1,49 +1,88 @@
 package middleware
 
 import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+type mockSecretsCache struct{
+	mock.Mock
+}
+
+type mockValue struct {
+	v string
+	e error
+}
+
+func (c *mockSecretsCache) GetSecretString(key string) (string, error) {
+	args := c.Called(key)
+	return args.String(0), args.Error(1)
+}
+
 func TestJwtVerify(t *testing.T) {
 	tests := []struct {
 		scenario     string
 		token        string
+		secret 		 mockValue
+		salt 		 mockValue
 		expectedCode int
 	}{
 		{
 			"Valid token",
 			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6OTk5OTk5OTk5OSwic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.8HtN6aTAnE2YFI9rJD8drzqgrXPkyUbwRRJymcPSmHk",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			200,
 		},
 		{
 			"Invalid token",
 			"NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6MTU4NzA1MjkxNywic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.f0oM4fSH_b1Xi5zEF0VK-t5uhpVidk5HY1O0EGR4SQQ",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			401,
 		},
 		{
 			"No token",
 			"",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			401,
 		},
 		{
 			"Wrong signing method",
 			"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DNSl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEbDRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6XxUTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7tuPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			401,
 		},
 		{
 			"Expired token",
 			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6MTU4NzA1MjMxNywic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.OuafGwOMHkXrFiQFrog8-zR14hxRwFkq5SeWXgvKi2o",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			401,
 		},
+		{
+			"Cannot fetch JWT secret",
+			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6MTU4NzA1MjMxNywic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.OuafGwOMHkXrFiQFrog8-zR14hxRwFkq5SeWXgvKi2o",
+			mockValue{"", errors.New("Missing secret")},
+			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
+			500,
+		},
+		{
+			"Cannot fetch salt secret",
+			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6OTk5OTk5OTk5OSwic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.8HtN6aTAnE2YFI9rJD8drzqgrXPkyUbwRRJymcPSmHk",
+			mockValue{"MyTestSecret", nil},
+			mockValue{"", errors.New("Missing secret")},
+			500,
+		},
 	}
-
-	os.Setenv("JWT_SECRET", "MyTestSecret")
-	os.Setenv("USER_HASH_SALT", "ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0")
 
 	for _, test := range tests {
 		req, err := http.NewRequest("GET", "/jwt", nil)
@@ -57,10 +96,16 @@ func TestJwtVerify(t *testing.T) {
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
 		rw := httptest.NewRecorder()
-		handler := JwtVerify(testHandler)
-		handler.ServeHTTP(rw, req)
 
-		assert.Equal(t, test.expectedCode, rw.Result().StatusCode, test.scenario)
+		mockCache := new(mockSecretsCache)
+		mockCache.On("GetSecretString", "jwt-key").Return(test.secret.v, test.secret.e)
+		mockCache.On("GetSecretString", "user-hash-salt").Return(test.salt.v, test.salt.e)
+		handler := JwtVerify(mockCache)(testHandler)
+		handler.ServeHTTP(rw, req)
+		res := rw.Result()
+		fmt.Println(fmt.Sprintf("%#v", res.Body))
+
+		assert.Equal(t, test.expectedCode, res.StatusCode, test.scenario)
 	}
 }
 

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"errors"
-	"fmt"
 	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
@@ -103,8 +102,6 @@ func TestJwtVerify(t *testing.T) {
 		handler := JwtVerify(mockCache)(testHandler)
 		handler.ServeHTTP(rw, req)
 		res := rw.Result()
-		fmt.Println(fmt.Sprintf("%#v", res.Body))
-
 		assert.Equal(t, test.expectedCode, res.StatusCode, test.scenario)
 	}
 }

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -41,7 +41,7 @@ func TestJwtVerify(t *testing.T) {
 		},
 		{
 			"Invalid token",
-			"NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6MTU4NzA1MjkxNywic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.f0oM4fSH_b1Xi5zEF0VK-t5uhpVidk5HY1O0EGR4SQQ",
+			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1ODcwNTIzMTcsImV4cCI6MTU4NzA1MjMxNywic2Vzc2lvbi1kYXRhIjoiVGVzdC5NY1Rlc3RGYWNlQG1haWwuY29tIn0.Db9h9JqwfdlS-LksLLqmdNYH8bQBxGTyFFL3086AxSE",
 			mockValue{"MyTestSecret", nil},
 			mockValue{"ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0", nil},
 			401,

--- a/middleware/jwt_auth_test.go
+++ b/middleware/jwt_auth_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockSecretsCache struct{
+type mockSecretsCache struct {
 	mock.Mock
 }
 

--- a/scripts/localstack/localstack_init.sh
+++ b/scripts/localstack/localstack_init.sh
@@ -2,3 +2,12 @@
 
 # Create ES domain
 awslocal es create-elasticsearch-domain --domain-name opg
+
+# Set secrets in Secrets Manager
+awslocal secretsmanager create-secret --name local/jwt-key \
+   --description "JWT secret for Go services authentication" \
+   --secret-string "MyTestSecret"
+
+awslocal secretsmanager create-secret --name local/user-hash-salt \
+   --description "Email salt for Go services authentication" \
+   --secret-string "ufUvZWyqrCikO1HPcPfrz7qQ6ENV84p0"


### PR DESCRIPTION
This PR is to amend the search service to fetch and cache the JWT secret and user has salt from AWS Secrets Manager instead of environment variables. This will allow the secrets to be rotated without requiring a restart. This includes the inclusion of the cache package and associated tests.