### PR TITLE
Limit concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"opg-search-service/cache"
 	"opg-search-service/cli"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"golang.org/x/net/netutil"
 )
 
 func main() {
@@ -303,7 +305,15 @@ func main() {
 
 	// start the server
 	go func() {
-		err := s.ListenAndServe()
+		ln, err := net.Listen("tcp", s.Addr)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		ln = netutil.LimitListener(ln, 2)
+
+		err = s.Serve(ln)
+
 		if err != nil {
 			l.Fatal(err)
 		}


### PR DESCRIPTION
Use the LimitListener to only allow 2 goroutines at a time. This ensures we don't overload Elasticsearch.