### PR TITLE
Apply personType filter after aggregation

### DIFF
--- a/person/search_handler.go
+++ b/person/search_handler.go
@@ -70,7 +70,6 @@ func (s SearchHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 						"default_operator": "AND",
 					},
 				},
-				"filter": filters,
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -78,6 +77,11 @@ func (s SearchHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				"terms": map[string]string{
 					"field": "personType",
 				},
+			},
+		},
+		"post_filter":  map[string]interface{}{
+			"bool": map[string]interface{}{
+				"should": filters,
 			},
 		},
 	}

--- a/person/search_handler_test.go
+++ b/person/search_handler_test.go
@@ -141,7 +141,18 @@ func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 							"default_operator": "AND",
 						},
 					},
-					"filter": []interface{}{
+				},
+			},
+			"aggs": map[string]interface{}{
+				"personType": map[string]interface{}{
+					"terms": map[string]string{
+						"field": "personType",
+					},
+				},
+			},
+			"post_filter": map[string]interface{}{
+				"bool": map[string]interface{}{
+					"should": []interface{}{
 						map[string]interface{}{
 							"term": map[string]string{
 								"personType": "type1",
@@ -152,13 +163,6 @@ func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 								"personType": "type2",
 							},
 						},
-					},
-				},
-			},
-			"aggs": map[string]interface{}{
-				"personType": map[string]interface{}{
-					"terms": map[string]string{
-						"field": "personType",
 					},
 				},
 			},


### PR DESCRIPTION
- Find entries based on the search query
- Perform aggregations to get count of each peron type matching the query
- Filter the actual results array to the requested types

Otherwise the aggregations will also take the filter on board, so if you request personType:Donor, it will only tell you how many donors match the search query.

For VEGA-870