### PR TITLE
Don't push containers from dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
     needs: ['gosec','test']
+    if: github.actor != 'dependabot[bot]'
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}


### PR DESCRIPTION
Dependabot doesn't have necessary permissions to create a Git tag or push containers (because it's external), so don't try and run this job on Dependabot PRs.

#patch