### PR TITLE
VEGA-1128 Handle address lines not being a JSON array

### DIFF
--- a/cli/reindex.go
+++ b/cli/reindex.go
@@ -98,8 +98,10 @@ func (c *reindexCommand) run() error {
 	var result *reindex.Result
 
 	if !fromDate.IsZero() {
+		c.logger.Printf("indexing by date from=%v", fromDate)
 		result, err = reindexer.ByDate(ctx, fromDate)
 	} else {
+		c.logger.Printf("indexing by id from=%d to=%d batchSize=%d", *c.from, *c.to, *c.batchSize)
 		result, err = reindexer.ByID(ctx, *c.from, *c.to, *c.batchSize)
 	}
 

--- a/internal/cmd/reindex/db.go
+++ b/internal/cmd/reindex/db.go
@@ -113,7 +113,7 @@ type rowResult struct {
 	Type               string
 	OrganisationName   string
 	AddressID          *int
-	AddressLines       []string
+	AddressLines       interface{}
 	Postcode           string
 	CaseID             *int
 	CasesUID           *int
@@ -173,7 +173,7 @@ func addResultToPerson(a *personAdded, p *person.Person, s rowResult) {
 
 	if s.AddressID != nil && !a.hasAddress(*s.AddressID) {
 		p.Addresses = append(p.Addresses, person.PersonAddress{
-			Addresslines: s.AddressLines,
+			Addresslines: getAddressLines(s.AddressLines),
 			Postcode:     s.Postcode,
 		})
 	}
@@ -194,5 +194,31 @@ func addResultToPerson(a *personAdded, p *person.Person, s rowResult) {
 			Casetype:      s.CasesCaseType,
 			Casesubtype:   s.CasesCaseSubType,
 		})
+	}
+}
+
+func getAddressLines(lines interface{}) []string {
+	switch v := lines.(type) {
+	case []interface{}:
+		r := make([]string, len(v))
+		for i, x := range v {
+			r[i] = x.(string)
+		}
+		return r
+
+	case map[string]interface{}:
+		r := make([]string, 3)
+		for k, x := range v {
+			i, err := strconv.Atoi(k)
+			if err != nil {
+				return nil
+			}
+
+			r[i] = x.(string)
+		}
+		return r
+
+	default:
+		return nil
 	}
 }

--- a/internal/cmd/reindex/db_test.go
+++ b/internal/cmd/reindex/db_test.go
@@ -38,7 +38,7 @@ INSERT INTO phonenumbers (id, person_id, phone_number)
 									VALUES (1, 1, '077777777');
 
 INSERT INTO addresses (id, person_id, address_lines, postcode)
-							 VALUES (1, 1, json_build_array('123 Fake St'), 'S1 1AB');
+							 VALUES (1, 1, json_build_object('0', '1 Road', '2', 'Place'), 'S1 1AB');
 
 INSERT INTO cases (id, uid, caserecnumber, onlinelpaid, batchid, casetype, casesubtype)
 					 VALUES (1, 7000, '545534', 'A123', 'x', 'lpa', 'hw'),
@@ -79,7 +79,7 @@ INSERT INTO person_caseitem (person_id, caseitem_id) VALUES (1, 1), (1, 2);
 				Phonenumber: "077777777",
 			}},
 			Addresses: []person.PersonAddress{{
-				Addresslines: []string{"123 Fake St"},
+				Addresslines: []string{"1 Road", "", "Place"},
 				Postcode:     "S1 1AB",
 			}},
 			Cases: []person.PersonCase{{


### PR DESCRIPTION
We sometimes have address lines like `{"0": "Something", "2": "Else"}`, or `{"0": "123 Road", "2": "City", "1": "Suburb"}`, which caused the `[]string` scanning to trip up.