### PR TITLE
VEGA-1128 Increase backoff with retries

### DIFF
--- a/cli/reindex.go
+++ b/cli/reindex.go
@@ -87,7 +87,7 @@ func (c *reindexCommand) run() error {
 		return err
 	}
 
-	reindexer := reindex.New(conn, c.esClient)
+	reindexer := reindex.New(conn, c.esClient, c.logger)
 
 	fromDate, err := time.Parse(time.RFC3339, *c.fromDate)
 

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -177,8 +177,8 @@ func (c *Client) DoBulk(op *BulkOp) (BulkResult, error) {
 	for {
 		res, err := c.doBulkOp(op)
 		if err == errTooManyRequests && retries < maxRetries {
-			time.Sleep(backoff)
 			retries++
+			time.Sleep(time.Duration(retries) * backoff)
 			continue
 		}
 

--- a/internal/cmd/reindex/db.go
+++ b/internal/cmd/reindex/db.go
@@ -15,6 +15,8 @@ func (r *Reindexer) queryByID(ctx context.Context, results chan<- person.Person,
 	batch := &batchIter{start: start, end: end, size: batchSize}
 
 	for batch.Next() {
+		r.log.Printf("reading range from db (%d, %d)", batch.From(), batch.To())
+
 		rows, err := r.conn.Query(ctx, makeQuery(`p.id >= $1 AND p.id <= $2`), batch.From(), batch.To())
 		if err != nil {
 			return err

--- a/internal/cmd/reindex/db_test.go
+++ b/internal/cmd/reindex/db_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockLogger struct{}
+
+func (*mockLogger) Printf(s string, args ...interface{}) {}
+
 func TestQueryByID(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
@@ -50,7 +54,7 @@ INSERT INTO person_caseitem (person_id, caseitem_id) VALUES (1, 1), (1, 2);
 		return
 	}
 
-	r := &Reindexer{conn: conn}
+	r := &Reindexer{conn: conn, log: &mockLogger{}}
 
 	resultsCh := make(chan person.Person)
 	results := []person.Person{}

--- a/internal/cmd/reindex/elasticsearch.go
+++ b/internal/cmd/reindex/elasticsearch.go
@@ -15,7 +15,14 @@ func (r *Reindexer) reindex(ctx context.Context, persons <-chan person.Person) (
 		err := op.Index(p.Id(), p)
 
 		if err == elasticsearch.ErrOpTooLarge {
-			result.Add(r.es.DoBulk(op))
+			res, bulkErr := r.es.DoBulk(op)
+			if bulkErr == nil {
+				r.log.Printf("batch indexed successful=%d failed=%d", res.Successful, res.Failed)
+			} else {
+				r.log.Printf("indexing error: %s", bulkErr.Error())
+			}
+
+			result.Add(res, bulkErr)
 			op.Reset()
 			err = op.Index(p.Id(), p)
 		}

--- a/internal/cmd/reindex/reindex.go
+++ b/internal/cmd/reindex/reindex.go
@@ -13,16 +13,22 @@ type BulkClient interface {
 	DoBulk(*elasticsearch.BulkOp) (elasticsearch.BulkResult, error)
 }
 
-func New(conn *pgx.Conn, es BulkClient) *Reindexer {
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+func New(conn *pgx.Conn, es BulkClient, logger Logger) *Reindexer {
 	return &Reindexer{
 		conn: conn,
 		es:   es,
+		log:  logger,
 	}
 }
 
 type Reindexer struct {
 	conn *pgx.Conn
 	es   BulkClient
+	log  Logger
 }
 
 func (r *Reindexer) ByID(ctx context.Context, start, end, batchSize int) (*Result, error) {


### PR DESCRIPTION
Ran in ~2 hours, but

```
{"level":"info","msg":"indexing done successful=19592153 failed=20360245","time":"2022-01-06T09:20:51Z"}
```

which I think is because it got a bit stuck half way through

![image](https://user-images.githubusercontent.com/146390/148362580-593afad1-5736-46d0-a726-3fe2b9e5ab4e.png)

This should slow indexing down more when ~Elastic~ OpenSearch complains about too many requests.