### PR TITLE
VEGA-1128 Capture and log an error if bulk index has failures

### DIFF
--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -114,6 +114,10 @@ type bulkResponse struct {
 		Index struct {
 			ID     string `json:"_id"`
 			Status int    `json:"status"`
+			Error  *struct {
+				Type   string `json:"type"`
+				Reason string `json:"reason"`
+			} `json:"error"`
 		} `json:"index"`
 	} `json:"items"`
 }
@@ -169,6 +173,7 @@ func (op *BulkOp) Reset() {
 type BulkResult struct {
 	Successful int
 	Failed     int
+	Error      string
 }
 
 func (c *Client) DoBulk(op *BulkOp) (BulkResult, error) {
@@ -220,6 +225,9 @@ func (c *Client) doBulkOp(op *BulkOp) (BulkResult, error) {
 			result.Successful += 1
 		} else {
 			result.Failed += 1
+			if d.Index.Error != nil && result.Error == "" {
+				result.Error = fmt.Sprintf("%s: %s", d.Index.Error.Type, d.Index.Error.Reason)
+			}
 		}
 	}
 

--- a/internal/cmd/reindex/elasticsearch.go
+++ b/internal/cmd/reindex/elasticsearch.go
@@ -17,7 +17,7 @@ func (r *Reindexer) reindex(ctx context.Context, persons <-chan person.Person) (
 		if err == elasticsearch.ErrOpTooLarge {
 			res, bulkErr := r.es.DoBulk(op)
 			if bulkErr == nil {
-				r.log.Printf("batch indexed successful=%d failed=%d", res.Successful, res.Failed)
+				r.log.Printf("batch indexed successful=%d failed=%d error=%s", res.Successful, res.Failed, res.Error)
 			} else {
 				r.log.Printf("indexing error: %s", bulkErr.Error())
 			}


### PR DESCRIPTION
Something else seems to be the issue, but since it is within the batches that the failure is happening the previous logging didn't show anything. I'm assuming that the same thing is affecting everything in the batch so just logging 1 per, otherwise there will be a lot to look through.