### PR TITLE
VEGA-1128 Make commands act like subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .idea
 *.iml
 .terraform
+opg-search-service

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -7,33 +7,45 @@ import (
 )
 
 type Command interface {
+	Name() string
 	DefineFlags()
 	ShouldRun() bool
-	Run()
+	Run(args []string) error
 }
 
-type commands struct {
-	logger *logrus.Logger
-}
-
-func Commands(logger *logrus.Logger) *commands {
-	c := commands{
-		logger,
-	}
-	return &c
-}
-
-func (c commands) Register(cmds ...Command) {
+func Run(logger *logrus.Logger, cmds ...Command) {
 	for _, cmd := range cmds {
 		cmd.DefineFlags()
 	}
 
 	flag.Parse()
+	args := flag.Args()
 
-	for _, cmd := range cmds {
-		if cmd.ShouldRun() {
-			c.logger.Printf("Running command: %T", cmd)
-			cmd.Run()
+	if len(args) > 0 {
+		for _, cmd := range cmds {
+			if cmd.Name() == args[0] {
+				logger.Printf("Running command: %T", cmd)
+				if err := cmd.Run(args[1:]); err != nil {
+					logger.Errorln(err)
+					logger.Exit(1)
+					return
+				}
+
+				logger.Exit(0)
+			}
+		}
+	} else {
+		for _, cmd := range cmds {
+			if cmd.ShouldRun() {
+				logger.Printf("Running command: %T", cmd)
+				if err := cmd.Run(args); err != nil {
+					logger.Errorln(err)
+					logger.Exit(1)
+					return
+				}
+
+				logger.Exit(0)
+			}
 		}
 	}
 }

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -9,7 +10,12 @@ import (
 )
 
 type MockCommand struct {
+	name string
 	mock.Mock
+}
+
+func (m *MockCommand) Name() string {
+	return "mock"
 }
 
 func (m *MockCommand) DefineFlags() {
@@ -21,34 +27,53 @@ func (m *MockCommand) ShouldRun() bool {
 	return args.Get(0).(bool)
 }
 
-func (m *MockCommand) Run() {
-	_ = m.Called()
+func (m *MockCommand) Run(xs []string) error {
+	args := m.Called(xs)
+	return args.Error(0)
 }
 
-func TestCommands(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	c := Commands(l)
+func TestCommandsRun(t *testing.T) {
+	exitCode := -1
 
-	assert.IsType(t, new(commands), c)
-	assert.Same(t, l, c.logger)
-}
-
-func TestCommands_Register(t *testing.T) {
 	l, hook := test.NewNullLogger()
+	l.ExitFunc = func(c int) {
+		exitCode = c
+	}
 
-	cmd1 := new(MockCommand)
-	cmd2 := new(MockCommand)
-
+	cmd1 := &MockCommand{}
 	cmd1.On("DefineFlags").Times(1).Return()
-	cmd2.On("DefineFlags").Times(1).Return()
-
 	cmd1.On("ShouldRun").Times(1).Return(false)
+
+	cmd2 := &MockCommand{}
+	cmd2.On("DefineFlags").Times(1).Return()
 	cmd2.On("ShouldRun").Times(1).Return(true)
+	cmd2.On("Run", []string{}).Times(1).Return(nil)
 
-	cmd2.On("Run").Times(1).Return()
+	Run(l, cmd1, cmd2)
 
-	c := commands{logger: l}
-	c.Register(cmd1, cmd2)
+	assert.Contains(t, "Running command: *cli.MockCommand", hook.LastEntry().Message)
+	assert.Equal(t, 0, exitCode)
+}
 
-	assert.Contains(t, hook.LastEntry().Message, "Running command: *cli.MockCommand")
+func TestCommandsRunErrors(t *testing.T) {
+	exitCode := -1
+
+	l, hook := test.NewNullLogger()
+	l.ExitFunc = func(c int) {
+		exitCode = c
+	}
+
+	cmd1 := &MockCommand{name: "1"}
+	cmd1.On("DefineFlags").Times(1).Return()
+	cmd1.On("ShouldRun").Times(1).Return(false)
+
+	cmd2 := &MockCommand{name: "2"}
+	cmd2.On("DefineFlags").Times(1).Return()
+	cmd2.On("ShouldRun").Times(1).Return(true)
+	cmd2.On("Run", []string{}).Times(1).Return(errors.New("what"))
+
+	Run(l, cmd1, cmd2)
+
+	assert.Equal(t, "what", hook.LastEntry().Message)
+	assert.Equal(t, 1, exitCode)
 }

--- a/cli/create_indices_test.go
+++ b/cli/create_indices_test.go
@@ -4,141 +4,98 @@ import (
 	"errors"
 	"opg-search-service/elasticsearch"
 	"opg-search-service/person"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewCreateIndices(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	ci := NewCreateIndices(l)
-	assert.IsType(t, new(createIndices), ci)
-	assert.IsType(t, new(elasticsearch.Client), ci.esClient)
-	assert.Nil(t, ci.shouldRun)
-	assert.IsType(t, os.Exit, ci.exit)
-	assert.Same(t, l, ci.logger)
-}
-
-func TestCreateIndices_DefineFlags(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	ci := NewCreateIndices(l)
-	assert.Nil(t, ci.shouldRun)
-	ci.DefineFlags()
-	assert.False(t, *ci.shouldRun)
-}
-
-func TestCreateIndices_ShouldRun(t *testing.T) {
-	tests := []struct {
-		scenario  string
-		shouldRun bool
-	}{
-		{
-			scenario:  "Command should run",
-			shouldRun: true,
-		},
-		{
-			scenario:  "Command should not run",
-			shouldRun: false,
-		},
-	}
-	for _, test := range tests {
-		ci := &createIndices{
-			shouldRun: &test.shouldRun,
-		}
-		assert.Equal(t, test.shouldRun, ci.ShouldRun(), test.scenario)
-	}
-}
-
-func TestCreateIndices_Run(t *testing.T) {
-	const ESErrorMessage = "some ES error"
+func TestCreateIndicesRun(t *testing.T) {
+	const esErrorMessage = "some ES error"
 
 	tests := []struct {
-		scenario     string
-		force        bool
-		esError      error
-		esExists     bool
-		esExistsErr  error
-		esDeleteErr  error
-		wantInLog    []string
-		wantExitCode int
+		scenario    string
+		force       bool
+		esError     error
+		esExists    bool
+		esExistsErr error
+		esDeleteErr error
+		wantInLog   []string
+		wantErr     error
 	}{
 		{
-			scenario:     "Index created successfully",
-			esError:      nil,
-			esExists:     false,
-			esExistsErr:  nil,
-			wantInLog:    []string{"Person index created successfully"},
-			wantExitCode: 0,
+			scenario:    "Index created successfully",
+			esError:     nil,
+			esExists:    false,
+			esExistsErr: nil,
+			wantInLog:   []string{"Person index created successfully"},
+			wantErr:     nil,
 		},
 		{
-			scenario:     "Error when creating index",
-			esError:      errors.New(ESErrorMessage),
-			esExists:     false,
-			esExistsErr:  nil,
-			wantInLog:    []string{ESErrorMessage},
-			wantExitCode: 1,
+			scenario:    "Error when creating index",
+			esError:     errors.New(esErrorMessage),
+			esExists:    false,
+			esExistsErr: nil,
+			wantInLog:   []string{},
+			wantErr:     errors.New(esErrorMessage),
 		},
 		{
-			scenario:     "Index already exists",
-			esError:      nil,
-			esExists:     true,
-			esExistsErr:  nil,
-			wantInLog:    []string{"Person index already exists"},
-			wantExitCode: 0,
+			scenario:    "Index already exists",
+			esError:     nil,
+			esExists:    true,
+			esExistsErr: nil,
+			wantInLog:   []string{"Person index already exists"},
+			wantErr:     nil,
 		},
 		{
-			scenario:     "Error when checking if index exists",
-			esError:      nil,
-			esExists:     false,
-			esExistsErr:  errors.New(ESErrorMessage),
-			wantInLog:    []string{ESErrorMessage},
-			wantExitCode: 1,
+			scenario:    "Error when checking if index exists",
+			esError:     nil,
+			esExists:    false,
+			esExistsErr: errors.New(esErrorMessage),
+			wantInLog:   []string{},
+			wantErr:     errors.New(esErrorMessage),
 		},
 		{
-			scenario:     "Force delete existing index",
-			force:        true,
-			esError:      nil,
-			esExists:     true,
-			esExistsErr:  nil,
-			wantInLog:    []string{"Person index already exists"},
-			wantExitCode: 0,
+			scenario:    "Force delete existing index",
+			force:       true,
+			esError:     nil,
+			esExists:    true,
+			esExistsErr: nil,
+			wantInLog:   []string{"Person index already exists"},
+			wantErr:     nil,
 		},
 		{
-			scenario:     "Error deleting existing index",
-			force:        true,
-			esError:      nil,
-			esExists:     true,
-			esExistsErr:  nil,
-			esDeleteErr:  errors.New(ESErrorMessage),
-			wantInLog:    []string{"Person index already exists", "Changes are forced, deleting old index", ESErrorMessage},
-			wantExitCode: 1,
+			scenario:    "Error deleting existing index",
+			force:       true,
+			esError:     nil,
+			esExists:    true,
+			esExistsErr: nil,
+			esDeleteErr: errors.New(esErrorMessage),
+			wantInLog:   []string{"Person index already exists", "Changes are forced, deleting old index"},
+			wantErr:     errors.New(esErrorMessage),
 		},
 	}
 	for _, tc := range tests {
-		l, hook := test.NewNullLogger()
+		t.Run(tc.scenario, func(t *testing.T) {
+			l, hook := test.NewNullLogger()
 
-		esClient := new(elasticsearch.MockESClient)
-		esClient.On("IndexExists", person.Person{}).Times(1).Return(tc.esExists, tc.esExistsErr)
-		esClient.On("DeleteIndex", person.Person{}).Times(1).Return(tc.esDeleteErr)
-		esClient.On("CreateIndex", person.Person{}).Times(1).Return(tc.esError == nil, tc.esError)
+			esClient := new(elasticsearch.MockESClient)
+			esClient.On("IndexExists", person.Person{}).Times(1).Return(tc.esExists, tc.esExistsErr)
+			esClient.On("DeleteIndex", person.Person{}).Times(1).Return(tc.esDeleteErr)
+			esClient.On("CreateIndex", person.Person{}).Times(1).Return(tc.esError == nil, tc.esError)
 
-		exitCode := 666
-		ci := createIndices{
-			logger:   l,
-			esClient: esClient,
-			force:    &tc.force,
-			exit: func(code int) {
-				exitCode = code
-			},
-		}
+			ci := createIndices{
+				logger:   l,
+				esClient: esClient,
+				force:    &tc.force,
+			}
 
-		ci.Run()
+			err := ci.Run([]string{})
+			assert.Equal(t, tc.wantErr, err)
 
-		for i, message := range tc.wantInLog {
-			assert.Contains(t, hook.Entries[i].Message, message, tc.scenario)
-		}
-		assert.Equal(t, tc.wantExitCode, exitCode, tc.scenario)
+			for i, message := range tc.wantInLog {
+				assert.Contains(t, message, hook.Entries[i].Message)
+			}
+		})
 	}
 }

--- a/cli/health_check.go
+++ b/cli/health_check.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"net/http"
 	"os"
@@ -12,15 +13,17 @@ type healthCheck struct {
 	logger    *logrus.Logger
 	shouldRun *bool
 	checkUrl  string
-	exit      func(code int)
 }
 
 func NewHealthCheck(logger *logrus.Logger) *healthCheck {
 	return &healthCheck{
 		logger:   logger,
 		checkUrl: "http://localhost:8000" + os.Getenv("PATH_PREFIX") + "/health-check",
-		exit:     os.Exit,
 	}
+}
+
+func (h *healthCheck) Name() string {
+	return "hc"
 }
 
 func (h *healthCheck) DefineFlags() {
@@ -31,13 +34,11 @@ func (h *healthCheck) ShouldRun() bool {
 	return *h.shouldRun
 }
 
-func (h *healthCheck) Run() {
+func (h *healthCheck) Run(args []string) error {
 	resp, err := http.Get(h.checkUrl)
 	if err != nil || resp.StatusCode != 200 {
-		h.logger.Println("FAIL")
-		h.exit(1)
-		return
+		return errors.New("FAIL")
 	}
 	h.logger.Println("OK")
-	h.exit(0)
+	return nil
 }

--- a/cli/health_check_test.go
+++ b/cli/health_check_test.go
@@ -1,95 +1,53 @@
 package cli
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewHealthCheck(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	hc := NewHealthCheck(l)
-
-	assert.IsType(t, new(healthCheck), hc)
-	assert.Same(t, l, hc.logger)
-	assert.Nil(t, hc.shouldRun)
-	assert.Equal(t, "http://localhost:8000"+os.Getenv("PATH_PREFIX")+"/health-check", hc.checkUrl)
-	assert.IsType(t, os.Exit, hc.exit)
-}
-
-func TestHealthCheck_DefineFlags(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	hc := NewHealthCheck(l)
-	assert.Nil(t, hc.shouldRun)
-	hc.DefineFlags()
-	assert.False(t, *hc.shouldRun)
-}
-
-func TestHealthCheck_ShouldRun(t *testing.T) {
-	tests := []struct {
-		scenario  string
-		shouldRun bool
-	}{
-		{
-			scenario:  "Command should run",
-			shouldRun: true,
-		},
-		{
-			scenario:  "Command should not run",
-			shouldRun: false,
-		},
-	}
-	for _, test := range tests {
-		hc := &healthCheck{
-			shouldRun: &test.shouldRun,
-		}
-		assert.Equal(t, test.shouldRun, hc.ShouldRun(), test.scenario)
-	}
-}
-
-func TestHealthCheck_Run(t *testing.T) {
+func TestHealthCheckRun(t *testing.T) {
 	tests := []struct {
 		scenario     string
 		responseCode int
-		wantInLog    string
-		wantExitCode int
+		wantInLog    []string
+		wantErr      error
 	}{
 		{
 			scenario:     "PASS",
 			responseCode: 200,
-			wantInLog:    "OK",
-			wantExitCode: 0,
+			wantInLog:    []string{"OK"},
+			wantErr:      nil,
 		},
 		{
 			scenario:     "FAIL",
 			responseCode: 500,
-			wantInLog:    "FAIL",
-			wantExitCode: 1,
+			wantInLog:    []string{},
+			wantErr:      errors.New("FAIL"),
 		},
 	}
 	for _, tc := range tests {
-		l, hook := test.NewNullLogger()
+		t.Run(tc.scenario, func(t *testing.T) {
+			l, hook := test.NewNullLogger()
 
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(tc.responseCode)
-		}))
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.responseCode)
+			}))
 
-		exitCode := 666
+			hc := &healthCheck{
+				logger:   l,
+				checkUrl: s.URL,
+			}
+			err := hc.Run([]string{})
 
-		hc := &healthCheck{
-			logger:   l,
-			checkUrl: s.URL,
-			exit: func(code int) {
-				exitCode = code
-			},
-		}
-		hc.Run()
-
-		assert.Contains(t, hook.LastEntry().Message, tc.wantInLog, tc.scenario)
-		assert.Equal(t, tc.wantExitCode, exitCode, tc.scenario)
+			assert.Equal(t, tc.wantErr, err)
+			for i, message := range tc.wantInLog {
+				assert.Contains(t, message, hook.Entries[i].Message)
+			}
+		})
 	}
 }

--- a/cli/index.go
+++ b/cli/index.go
@@ -51,6 +51,7 @@ func (c *indexCommand) ShouldRun() bool {
 func (c *indexCommand) Run(args []string) error {
 	flagset := flag.NewFlagSet("index", flag.ExitOnError)
 
+	all := flagset.Bool("all", false, "index all records")
 	from := flagset.Int("from", 0, "id to index from")
 	to := flagset.Int("to", 100, "id to index to")
 	batchSize := flagset.Int("batch-size", 10000, "batch size to read from db")
@@ -90,6 +91,9 @@ func (c *indexCommand) Run(args []string) error {
 	if !fromTime.IsZero() {
 		c.logger.Printf("indexing by date from=%v", fromDate)
 		result, err = indexer.ByDate(ctx, fromTime)
+	} else if *all {
+		c.logger.Printf("indexing all records batchSize=%d", *batchSize)
+		result, err = indexer.All(ctx, *batchSize)
 	} else {
 		c.logger.Printf("indexing by id from=%d to=%d batchSize=%d", *from, *to, *batchSize)
 		result, err = indexer.ByID(ctx, *from, *to, *batchSize)

--- a/cli/index_test.go
+++ b/cli/index_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReindex(t *testing.T) {
+func TestIndex(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
 	l, hook := test.NewNullLogger()
-	command := NewReindex(l, nil)
+	command := NewIndex(l, nil)
 
 	os.Setenv("SEARCH_SERVICE_DB_PASS", "searchservice")
 	os.Setenv("SEARCH_SERVICE_DB_USER", "searchservice")

--- a/cli/reindex_test.go
+++ b/cli/reindex_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"flag"
 	"os"
 	"testing"
 
@@ -17,13 +16,6 @@ func TestReindex(t *testing.T) {
 
 	l, hook := test.NewNullLogger()
 	command := NewReindex(l, nil)
-
-	command.DefineFlags()
-
-	os.Args = []string{"", "-reindex"}
-	flag.Parse()
-
-	assert.True(command.ShouldRun())
 
 	os.Setenv("SEARCH_SERVICE_DB_PASS", "searchservice")
 	os.Setenv("SEARCH_SERVICE_DB_USER", "searchservice")
@@ -46,7 +38,7 @@ func TestReindex(t *testing.T) {
 		return
 	}
 
-	err = command.run()
+	err = command.Run([]string{})
 	assert.Nil(err)
 	assert.Equal("indexing done successful=0 failed=0", hook.LastEntry().Message)
 }

--- a/internal/cmd/index/batch_iter.go
+++ b/internal/cmd/index/batch_iter.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 // batchIter iterates over the range start-end (inclusive) giving batches of
 // size

--- a/internal/cmd/index/batch_iter_test.go
+++ b/internal/cmd/index/batch_iter_test.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"testing"

--- a/internal/cmd/index/db.go
+++ b/internal/cmd/index/db.go
@@ -9,6 +9,12 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
+func (r *Indexer) getIDRange(ctx context.Context) (min int, max int, err error) {
+	err = r.conn.QueryRow(ctx, "SELECT MIN(id), MAX(id) FROM persons").Scan(&min, &max)
+
+	return min, max, err
+}
+
 func (r *Indexer) queryByID(ctx context.Context, results chan<- person.Person, start, end, batchSize int) error {
 	defer func() { close(results) }()
 

--- a/internal/cmd/index/db.go
+++ b/internal/cmd/index/db.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-func (r *Reindexer) queryByID(ctx context.Context, results chan<- person.Person, start, end, batchSize int) error {
+func (r *Indexer) queryByID(ctx context.Context, results chan<- person.Person, start, end, batchSize int) error {
 	defer func() { close(results) }()
 
 	batch := &batchIter{start: start, end: end, size: batchSize}
@@ -30,7 +30,7 @@ func (r *Reindexer) queryByID(ctx context.Context, results chan<- person.Person,
 	return nil
 }
 
-func (r *Reindexer) queryByDate(ctx context.Context, results chan<- person.Person, from time.Time) error {
+func (r *Indexer) queryByDate(ctx context.Context, results chan<- person.Person, from time.Time) error {
 	rows, err := r.conn.Query(ctx, makeQuery(`p.updatedDate >= $1`), from)
 	if err != nil {
 		return err

--- a/internal/cmd/index/db_test.go
+++ b/internal/cmd/index/db_test.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"context"
@@ -54,7 +54,7 @@ INSERT INTO person_caseitem (person_id, caseitem_id) VALUES (1, 1), (1, 2);
 		return
 	}
 
-	r := &Reindexer{conn: conn, log: &mockLogger{}}
+	r := &Indexer{conn: conn, log: &mockLogger{}}
 
 	resultsCh := make(chan person.Person)
 	results := []person.Person{}
@@ -162,7 +162,7 @@ INSERT INTO person_caseitem (person_id, caseitem_id) VALUES (1, 1), (1, 2);
 		return
 	}
 
-	r := &Reindexer{conn: conn}
+	r := &Indexer{conn: conn}
 
 	resultsCh := make(chan person.Person)
 	results := []person.Person{}

--- a/internal/cmd/index/elasticsearch.go
+++ b/internal/cmd/index/elasticsearch.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"opg-search-service/person"
 )
 
-func (r *Reindexer) reindex(ctx context.Context, persons <-chan person.Person) (*Result, error) {
+func (r *Indexer) index(ctx context.Context, persons <-chan person.Person) (*Result, error) {
 	op := elasticsearch.NewBulkOp("person")
 	result := &Result{}
 

--- a/internal/cmd/index/elasticsearch_test.go
+++ b/internal/cmd/index/elasticsearch_test.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"context"
@@ -21,14 +21,14 @@ func (c *mockBulkClient) DoBulk(op *elasticsearch.BulkOp) (elasticsearch.BulkRes
 	return c.result, c.err
 }
 
-func TestReindex(t *testing.T) {
+func TestIndex(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
 	client := &mockBulkClient{
 		result: elasticsearch.BulkResult{Successful: 1, Failed: 0},
 	}
-	r := &Reindexer{es: client}
+	r := &Indexer{es: client}
 
 	p := person.Person{ID: i64(1), Firstname: "A"}
 
@@ -39,7 +39,7 @@ func TestReindex(t *testing.T) {
 	expectedOp := elasticsearch.NewBulkOp("person")
 	expectedOp.Index(p.Id(), p)
 
-	result, err := r.reindex(ctx, persons)
+	result, err := r.index(ctx, persons)
 	if assert.Nil(err) {
 		assert.Equal(1, result.Successful)
 		assert.Equal(0, result.Failed)

--- a/internal/cmd/index/index.go
+++ b/internal/cmd/index/index.go
@@ -1,4 +1,4 @@
-package reindex
+package index
 
 import (
 	"context"
@@ -17,21 +17,21 @@ type Logger interface {
 	Printf(string, ...interface{})
 }
 
-func New(conn *pgx.Conn, es BulkClient, logger Logger) *Reindexer {
-	return &Reindexer{
+func New(conn *pgx.Conn, es BulkClient, logger Logger) *Indexer {
+	return &Indexer{
 		conn: conn,
 		es:   es,
 		log:  logger,
 	}
 }
 
-type Reindexer struct {
+type Indexer struct {
 	conn *pgx.Conn
 	es   BulkClient
 	log  Logger
 }
 
-func (r *Reindexer) ByID(ctx context.Context, start, end, batchSize int) (*Result, error) {
+func (r *Indexer) ByID(ctx context.Context, start, end, batchSize int) (*Result, error) {
 	var rerr error
 	persons := make(chan person.Person, batchSize)
 
@@ -42,7 +42,7 @@ func (r *Reindexer) ByID(ctx context.Context, start, end, batchSize int) (*Resul
 		}
 	}()
 
-	result, err := r.reindex(ctx, persons)
+	result, err := r.index(ctx, persons)
 	if rerr != nil {
 		return result, rerr
 	}
@@ -50,7 +50,7 @@ func (r *Reindexer) ByID(ctx context.Context, start, end, batchSize int) (*Resul
 	return result, err
 }
 
-func (r *Reindexer) ByDate(ctx context.Context, from time.Time) (*Result, error) {
+func (r *Indexer) ByDate(ctx context.Context, from time.Time) (*Result, error) {
 	var rerr error
 	persons := make(chan person.Person, 100)
 
@@ -61,7 +61,7 @@ func (r *Reindexer) ByDate(ctx context.Context, from time.Time) (*Result, error)
 		}
 	}()
 
-	result, err := r.reindex(ctx, persons)
+	result, err := r.index(ctx, persons)
 	if rerr != nil {
 		return result, rerr
 	}

--- a/internal/cmd/index/index.go
+++ b/internal/cmd/index/index.go
@@ -31,6 +31,15 @@ type Indexer struct {
 	log  Logger
 }
 
+func (r *Indexer) All(ctx context.Context, batchSize int) (*Result, error) {
+	min, max, err := r.getIDRange(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.ByID(ctx, min, max, batchSize)
+}
+
 func (r *Indexer) ByID(ctx context.Context, start, end, batchSize int) (*Result, error) {
 	var rerr error
 	persons := make(chan person.Person, batchSize)

--- a/main.go
+++ b/main.go
@@ -24,8 +24,7 @@ func main() {
 
 	secretsCache := cache.New()
 
-	// Register CLI commands
-	cli.Commands(l).Register(
+	cli.Run(l,
 		cli.NewHealthCheck(l),
 		cli.NewCreateIndices(l),
 		cli.NewReindex(l, secretsCache),

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 	cli.Run(l,
 		cli.NewHealthCheck(l),
 		cli.NewCreateIndices(l),
-		cli.NewReindex(l, secretsCache),
+		cli.NewIndex(l, secretsCache),
 	)
 
 	// Create persons index if it doesn't exist


### PR DESCRIPTION
Currently everything is a global flag, which means we wouldn't be able to introduce something else with `-force`, for example. This makes things callable as subcommands, which can then define their own flagset.

```sh
search-service -create-indices -force
# will become
search-service create-indices -force
```

To allow transitioning existing uses `-hc` and `-create-indices` can still be called the old way too.

This also:
- renames everything `reindex` to `index`
- adds an `-all` flag so you don't have to specify an ID range
- removes the `opg-search-service` binary from the repo, and adds it to the `.gitignore`