### PR TITLE
VEGA-1160 Index to person and person_hash

### DIFF
--- a/cli/index.go
+++ b/cli/index.go
@@ -52,6 +52,7 @@ func (c *indexCommand) Run(args []string) error {
 	to := flagset.Int("to", 100, "id to index to")
 	batchSize := flagset.Int("batch-size", 10000, "batch size to read from db")
 	fromDate := flagset.String("from-date", "", "index all records updated from this date")
+	hash := flagset.Bool("hash", false, "index to the person_hash index")
 
 	if err := flagset.Parse(args); err != nil {
 		return err
@@ -74,7 +75,12 @@ func (c *indexCommand) Run(args []string) error {
 		return err
 	}
 
-	indexer := index.New(conn, c.esClient, c.logger, c.indexName)
+	indexName := "person"
+	if *hash {
+		indexName = c.indexName
+	}
+
+	indexer := index.New(conn, c.esClient, c.logger, indexName)
 
 	fromTime, err := time.Parse(time.RFC3339, *fromDate)
 

--- a/cli/index.go
+++ b/cli/index.go
@@ -20,21 +20,23 @@ type Secrets interface {
 }
 
 type indexCommand struct {
-	logger   *logrus.Logger
-	esClient index.BulkClient
-	secrets  Secrets
+	logger    *logrus.Logger
+	esClient  index.BulkClient
+	secrets   Secrets
+	indexName string
 }
 
-func NewIndex(logger *logrus.Logger, secrets Secrets) *indexCommand {
+func NewIndex(logger *logrus.Logger, secrets Secrets, indexName string) *indexCommand {
 	esClient, err := elasticsearch.NewClient(&http.Client{}, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 
 	return &indexCommand{
-		logger:   logger,
-		esClient: esClient,
-		secrets:  secrets,
+		logger:    logger,
+		esClient:  esClient,
+		secrets:   secrets,
+		indexName: indexName,
 	}
 }
 
@@ -72,7 +74,7 @@ func (c *indexCommand) Run(args []string) error {
 		return err
 	}
 
-	indexer := index.New(conn, c.esClient, c.logger)
+	indexer := index.New(conn, c.esClient, c.logger, c.indexName)
 
 	fromTime, err := time.Parse(time.RFC3339, *fromDate)
 

--- a/cli/index_test.go
+++ b/cli/index_test.go
@@ -15,7 +15,7 @@ func TestIndex(t *testing.T) {
 	ctx := context.Background()
 
 	l, hook := test.NewNullLogger()
-	command := NewIndex(l, nil)
+	command := NewIndex(l, nil, "test-index")
 
 	os.Setenv("SEARCH_SERVICE_DB_PASS", "searchservice")
 	os.Setenv("SEARCH_SERVICE_DB_USER", "searchservice")

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -28,13 +28,6 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type ClientInterface interface {
-	DoBulk(op *BulkOp) (BulkResult, error)
-	Search(indexName string, requestBody map[string]interface{}) (*SearchResult, error)
-	CreateIndex(name string, config []byte, force bool) error
-	IndexExists(name string) (bool, error)
-}
-
 type Client struct {
 	httpClient HTTPClient
 	logger     *logrus.Logger

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -30,17 +30,9 @@ type HTTPClient interface {
 
 type ClientInterface interface {
 	DoBulk(op *BulkOp) (BulkResult, error)
-	Search(requestBody map[string]interface{}, dataType Indexable) (*SearchResult, error)
-	CreateIndex(i Indexable) (bool, error)
-	DeleteIndex(i Indexable) error
-	IndexExists(i Indexable) (bool, error)
-}
-
-type Indexable interface {
-	Id() int64
-	IndexName() string
-	Json() string
-	IndexConfig() map[string]interface{}
+	Search(indexName string, requestBody map[string]interface{}) (*SearchResult, error)
+	CreateIndex(name string, config []byte, force bool) error
+	IndexExists(name string) (bool, error)
 }
 
 type Client struct {
@@ -235,8 +227,8 @@ func (c *Client) doBulkOp(op *BulkOp) (BulkResult, error) {
 }
 
 // returns an array of JSON encoded results
-func (c *Client) Search(requestBody map[string]interface{}, dataType Indexable) (*SearchResult, error) {
-	endpoint := c.domain + "/" + dataType.IndexName() + "/_search"
+func (c *Client) Search(indexName string, requestBody map[string]interface{}) (*SearchResult, error) {
+	endpoint := c.domain + "/" + indexName + "/_search"
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(requestBody); err != nil {
@@ -285,16 +277,46 @@ func (c *Client) Search(requestBody map[string]interface{}, dataType Indexable) 
 	}, nil
 }
 
-func (c *Client) IndexExists(i Indexable) (bool, error) {
-	c.logger.Printf("Checking index '%s' exists", i.IndexName())
+func (c *Client) CreateIndex(name string, config []byte, force bool) error {
+	exists, err := c.IndexExists(name)
+	if err != nil {
+		return err
+	}
 
-	endpoint := c.domain + "/" + i.IndexName()
+	if exists {
+		if !force {
+			c.logger.Printf("index '%s' already exists", name)
+			return nil
+		}
+
+		c.logger.Printf("changes are forced, deleting old index '%s'", name)
+
+		if err := c.deleteIndex(name); err != nil {
+			return err
+		}
+
+		c.logger.Printf("index '%s' deleted", name)
+	}
+
+	if err := c.createIndex(name, config); err != nil {
+		return err
+	}
+
+	c.logger.Printf("index '%s' created", name)
+	return nil
+}
+
+func (c *Client) IndexExists(name string) (bool, error) {
+	c.logger.Printf("Checking index '%s' exists", name)
+
+	endpoint := c.domain + "/" + name
 
 	body := bytes.NewReader([]byte(""))
 	resp, err := c.doRequest(http.MethodHead, endpoint, body, "")
 	if err != nil {
 		return false, err
 	}
+	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -303,47 +325,34 @@ func (c *Client) IndexExists(i Indexable) (bool, error) {
 		return false, nil
 	}
 
-	return false, errors.New(fmt.Sprintf(`index check failed with status code %d`, resp.StatusCode))
+	return false, fmt.Errorf("index check failed with status code %d", resp.StatusCode)
 }
 
-func (c *Client) CreateIndex(i Indexable) (bool, error) {
-	c.logger.Printf("Creating index '%s' for %T", i.IndexName(), i)
+func (c *Client) createIndex(name string, config []byte) error {
+	c.logger.Printf("Creating index '%s'", name)
 
-	endpoint := c.domain + "/" + i.IndexName()
+	endpoint := c.domain + "/" + name
 
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(i.IndexConfig()); err != nil {
-		return false, err
-	}
-	body := bytes.NewReader(buf.Bytes())
-
-	resp, err := c.doRequest(http.MethodPut, endpoint, body, "application/json")
+	resp, err := c.doRequest(http.MethodPut, endpoint, bytes.NewReader(config), "application/json")
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		buf.Reset()
-		_, _ = buf.ReadFrom(resp.Body)
-		return false, errors.New(fmt.Sprintf(`index creation failed with status code %d and response: "%s"`, resp.StatusCode, buf.String()))
+		data, _ := io.ReadAll(resp.Body)
+		return errors.New(fmt.Sprintf(`index creation failed with status code %d and response: "%s"`, resp.StatusCode, string(data)))
 	}
 
-	return true, nil
+	return nil
 }
 
-func (c *Client) DeleteIndex(i Indexable) error {
-	c.logger.Printf("Deleting index '%s' for %T", i.IndexName(), i)
+func (c *Client) deleteIndex(name string) error {
+	c.logger.Printf("Deleting index '%s'", name)
 
-	endpoint := c.domain + "/" + i.IndexName()
+	endpoint := c.domain + "/" + name
 
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(i.IndexConfig()); err != nil {
-		return err
-	}
-	body := bytes.NewReader(buf.Bytes())
-
-	resp, err := c.doRequest(http.MethodDelete, endpoint, body, "application/json")
+	resp, err := c.doRequest(http.MethodDelete, endpoint, nil, "application/json")
 	if err != nil {
 		return err
 	}

--- a/elasticsearch/client_mock.go
+++ b/elasticsearch/client_mock.go
@@ -11,22 +11,12 @@ func (m *MockESClient) DoBulk(op *BulkOp) (BulkResult, error) {
 	return args.Get(0).(BulkResult), args.Error(1)
 }
 
-func (m *MockESClient) Search(requestBody map[string]interface{}, dataType Indexable) (*SearchResult, error) {
-	args := m.Called(requestBody, dataType)
+func (m *MockESClient) Search(indexName string, requestBody map[string]interface{}) (*SearchResult, error) {
+	args := m.Called(indexName, requestBody)
 	return args.Get(0).(*SearchResult), args.Error(1)
 }
 
-func (m *MockESClient) CreateIndex(i Indexable) (bool, error) {
-	args := m.Called(i)
-	return args.Get(0).(bool), args.Error(1)
-}
-
-func (m *MockESClient) IndexExists(i Indexable) (bool, error) {
-	args := m.Called(i)
-	return args.Get(0).(bool), args.Error(1)
-}
-
-func (m *MockESClient) DeleteIndex(i Indexable) error {
-	args := m.Called(i)
+func (m *MockESClient) CreateIndex(name string, config []byte, force bool) error {
+	args := m.Called(name, config, force)
 	return args.Error(0)
 }

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+var indexConfig = []byte("{json}")
+
 type MockHttpClient struct {
 	mock.Mock
 }
@@ -22,30 +25,6 @@ type MockHttpClient struct {
 func (m *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)
-}
-
-type MockIndexable struct {
-	mock.Mock
-}
-
-func (m *MockIndexable) Id() int64 {
-	args := m.Called()
-	return args.Get(0).(int64)
-}
-
-func (m *MockIndexable) IndexName() string {
-	args := m.Called()
-	return args.Get(0).(string)
-}
-
-func (m *MockIndexable) Json() string {
-	args := m.Called()
-	return args.Get(0).(string)
-}
-
-func (m *MockIndexable) IndexConfig() map[string]interface{} {
-	args := m.Called()
-	return args.Get(0).(map[string]interface{})
 }
 
 func TestClient_DoBulkIndex(t *testing.T) {
@@ -99,11 +78,6 @@ func TestClient_DoBulkIndex(t *testing.T) {
 			assert.IsType(&Client{}, c)
 			assert.Nil(err)
 
-			mi := new(MockIndexable)
-			mi.On("Id").Return(int64(6)).Times(3)
-			mi.On("IndexName").Return("test-index").Times(1)
-			mi.On("Json").Return("{\"test\":\"test\"}")
-
 			mcCall := mc.On("Do", mock.AnythingOfType("*http.Request"))
 			mcCall.RunFn = func(args mock.Arguments) {
 				req := args[0].(*http.Request)
@@ -151,11 +125,6 @@ func TestClient_DoBulkIndexWithRetry(t *testing.T) {
 
 	assert.IsType(&Client{}, c)
 	assert.Nil(err)
-
-	mi := new(MockIndexable)
-	mi.On("Id").Return(int64(6)).Times(3)
-	mi.On("IndexName").Return("test-index").Times(1)
-	mi.On("Json").Return("{\"test\":\"test\"}")
 
 	mc.On("Do", mock.AnythingOfType("*http.Request")).
 		Run(func(args mock.Arguments) {
@@ -206,201 +175,185 @@ func TestClient_DoBulkIndexWithRetry(t *testing.T) {
 	assert.Equal(BulkResult{Successful: 1}, result)
 }
 
-func TestClient_CreateIndex(t *testing.T) {
-	tests := []struct {
-		scenario          string
-		esResponseError   error
-		esResponseCode    int
-		esResponseMessage string
-		expectedError     error
-	}{
-		{
-			scenario:          "Index created successfully",
-			esResponseError:   nil,
-			esResponseCode:    200,
-			esResponseMessage: "test message",
-			expectedError:     nil,
-		},
-		{
-			scenario:          "Create index request unexpected failure",
-			esResponseError:   errors.New("some ES error"),
-			esResponseCode:    500,
-			esResponseMessage: "test message",
-			expectedError:     errors.New("some ES error"),
-		},
-		{
-			scenario:          "Create index request validation failure",
-			esResponseError:   nil,
-			esResponseCode:    400,
-			esResponseMessage: "test message",
-			expectedError:     errors.New(`index creation failed with status code 400 and response: "test message"`),
-		},
-	}
+func TestClientCreateIndex(t *testing.T) {
+	assert := assert.New(t)
 
-	for _, test := range tests {
-		t.Run(test.scenario, func(t *testing.T) {
-			mc := new(MockHttpClient)
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
 
-			l, hook := logrus_test.NewNullLogger()
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
 
-			c, err := NewClient(mc, l)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-			assert.IsType(t, &Client{}, c)
-			assert.Nil(t, err)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			data, _ := io.ReadAll(req.Body)
 
-			mi := new(MockIndexable)
-			mi.On("IndexName").Return("test-index").Times(2)
-			mi.On("IndexConfig").Return(map[string]interface{}{"test": "test"}).Times(1)
+			return req.Method == http.MethodPut &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index" &&
+				bytes.Equal(data, indexConfig)
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader("test message"))}, nil).
+		Once()
 
-			mcCall := mc.On("Do", mock.AnythingOfType("*http.Request"))
-			mcCall.RunFn = func(args mock.Arguments) {
-				req := args[0].(*http.Request)
-				assert.Equal(t, http.MethodPut, req.Method)
-				assert.Equal(t, os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index", req.URL.String())
-				reqBuf := new(bytes.Buffer)
-				_, _ = reqBuf.ReadFrom(req.Body)
-				assert.Equal(t, `{"test":"test"}`, strings.TrimSpace(reqBuf.String()))
-			}
-			mcCall.Return(
-				&http.Response{
-					StatusCode: test.esResponseCode,
-					Body:       ioutil.NopCloser(strings.NewReader(test.esResponseMessage)),
-				},
-				test.esResponseError,
-			)
-
-			result, err := c.CreateIndex(mi)
-
-			assert.Contains(t, hook.LastEntry().Message, "Creating index 'test-index' for *elasticsearch.MockIndexable")
-			assert.Equal(t, test.expectedError == nil, result)
-			assert.Equal(t, test.expectedError, err)
-		})
-	}
+	err = client.CreateIndex("test-index", indexConfig, false)
+	assert.Nil(err)
+	assert.Contains(hook.LastEntry().Message, "index 'test-index' created")
 }
 
-func TestClient_CreateIndex_MalformedEndpoint(t *testing.T) {
-	oldESEndpoint := os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")
-	_ = os.Setenv("AWS_ELASTICSEARCH_ENDPOINT", ":-:/-=")
+func TestClientCreateIndexWhenIndexExists(t *testing.T) {
+	assert := assert.New(t)
 
-	mc := new(MockHttpClient)
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
 
-	l, _ := logrus_test.NewNullLogger()
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
 
-	c, _ := NewClient(mc, l)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-	mi := new(MockIndexable)
-	mi.On("IndexName").Return("test-index").Times(2)
-	mi.On("IndexConfig").Return(map[string]interface{}{"test": "test"}).Times(1)
-
-	res, err := c.CreateIndex(mi)
-
-	assert.False(t, res)
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "missing protocol scheme")
-
-	_ = os.Setenv("AWS_ELASTICSEARCH_ENDPOINT", oldESEndpoint)
+	err = client.CreateIndex("test-index", indexConfig, false)
+	assert.Nil(err)
+	assert.Contains(hook.LastEntry().Message, "index 'test-index' already exists")
 }
 
-func TestClient_DeleteIndex(t *testing.T) {
-	tests := []struct {
-		scenario        string
-		esResponseError error
-		esResponseCode  int
-		expectedError   error
-	}{
-		{
-			scenario:        "Index deleted successfully",
-			esResponseError: nil,
-			esResponseCode:  200,
-			expectedError:   nil,
-		},
-		{
-			scenario:        "Delete index request unexpected failure",
-			esResponseError: errors.New("some ES error"),
-			esResponseCode:  500,
-			expectedError:   errors.New("some ES error"),
-		},
-	}
+func TestClientCreateIndexWhenIndexExistsAndForced(t *testing.T) {
+	assert := assert.New(t)
 
-	for _, test := range tests {
-		t.Run(test.scenario, func(t *testing.T) {
-			mc := new(MockHttpClient)
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
 
-			l, hook := logrus_test.NewNullLogger()
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
 
-			c, err := NewClient(mc, l)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-			assert.IsType(t, &Client{}, c)
-			assert.Nil(t, err)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodDelete &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-			mi := new(MockIndexable)
-			mi.On("IndexName").Return("test-index").Times(2)
-			mi.On("IndexConfig").Return(map[string]interface{}{"test": "test"}).Times(1)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			data, _ := io.ReadAll(req.Body)
 
-			mcCall := mc.On("Do", mock.AnythingOfType("*http.Request"))
-			mcCall.RunFn = func(args mock.Arguments) {
-				req := args[0].(*http.Request)
-				assert.Equal(t, http.MethodDelete, req.Method)
-				assert.Equal(t, os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index", req.URL.String())
-			}
-			mcCall.Return(
-				&http.Response{
-					StatusCode: test.esResponseCode,
-					Body:       ioutil.NopCloser(strings.NewReader("")),
-				},
-				test.esResponseError,
-			)
+			return req.Method == http.MethodPut &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index" &&
+				bytes.Equal(data, indexConfig)
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader("test message"))}, nil).
+		Once()
 
-			err = c.DeleteIndex(mi)
-
-			assert.Contains(t, hook.LastEntry().Message, "Deleting index 'test-index' for *elasticsearch.MockIndexable")
-			assert.Equal(t, test.expectedError, err)
-		})
-	}
+	err = client.CreateIndex("test-index", indexConfig, true)
+	assert.Nil(err)
+	assert.Contains(hook.LastEntry().Message, "index 'test-index' created")
 }
 
-func TestClient_DeleteIndex_MalformedEndpoint(t *testing.T) {
-	oldESEndpoint := os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")
-	_ = os.Setenv("AWS_ELASTICSEARCH_ENDPOINT", ":-:/-=")
+func TestClientCreateIndexErrorIndexExists(t *testing.T) {
+	assert := assert.New(t)
 
-	mc := new(MockHttpClient)
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
 
-	l, _ := logrus_test.NewNullLogger()
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
 
-	c, _ := NewClient(mc, l)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusInternalServerError, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-	mi := new(MockIndexable)
-	mi.On("IndexName").Return("test-index").Times(2)
-	mi.On("IndexConfig").Return(map[string]interface{}{"test": "test"}).Times(1)
-
-	err := c.DeleteIndex(mi)
-
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "missing protocol scheme")
-
-	_ = os.Setenv("AWS_ELASTICSEARCH_ENDPOINT", oldESEndpoint)
+	err = client.CreateIndex("test-index", indexConfig, false)
+	assert.NotNil(err)
+	assert.Contains(hook.LastEntry().Message, "Checking index 'test-index' exists")
 }
 
-func TestClient_Search_InvalidIndexConfig(t *testing.T) {
-	mc := new(MockHttpClient)
+func TestClientCreateIndexErrorDeleteIndex(t *testing.T) {
+	assert := assert.New(t)
 
-	l, _ := logrus_test.NewNullLogger()
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
 
-	c, _ := NewClient(mc, l)
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
 
-	indexConfig := map[string]interface{}{
-		"test": func() {},
-	}
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
 
-	mi := new(MockIndexable)
-	mi.On("IndexName").Return("test-index").Times(2)
-	mi.On("IndexConfig").Return(indexConfig).Times(1)
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodDelete &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, errors.New("hey")).
+		Once()
 
-	res, err := c.CreateIndex(mi)
+	err = client.CreateIndex("test-index", indexConfig, true)
+	assert.NotNil(err)
+	assert.Contains(hook.LastEntry().Message, "Deleting index 'test-index'")
+}
 
-	assert.False(t, res)
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "json: unsupported type: func()")
+func TestClientCreateIndexErrorCreateIndex(t *testing.T) {
+	assert := assert.New(t)
+
+	httpClient := &MockHttpClient{}
+	l, hook := logrus_test.NewNullLogger()
+
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
+
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodHead &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index"
+		})).
+		Return(&http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
+		Once()
+
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			data, _ := io.ReadAll(req.Body)
+
+			return req.Method == http.MethodPut &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index" &&
+				bytes.Equal(data, indexConfig)
+		})).
+		Return(&http.Response{StatusCode: http.StatusOK}, errors.New("hey")).
+		Once()
+
+	err = client.CreateIndex("test-index", indexConfig, false)
+	assert.NotNil(err)
+	assert.Contains(hook.LastEntry().Message, "Creating index 'test-index'")
 }
 
 func TestClient_Search(t *testing.T) {
@@ -483,9 +436,6 @@ func TestClient_Search(t *testing.T) {
 				"term": "test",
 			}
 
-			mi := new(MockIndexable)
-			mi.On("IndexName").Return("test-index").Times(1)
-
 			mcCall := mc.On("Do", mock.AnythingOfType("*http.Request"))
 			mcCall.RunFn = func(args mock.Arguments) {
 				req := args[0].(*http.Request)
@@ -503,7 +453,7 @@ func TestClient_Search(t *testing.T) {
 				test.esResponseError,
 			)
 
-			result, err := c.Search(reqBody, mi)
+			result, err := c.Search("test-index", reqBody)
 
 			assert.Equal(test.expectedResult, result)
 			if test.expectedError == nil {
@@ -525,10 +475,7 @@ func TestClient_Search_MalformedEndpoint(t *testing.T) {
 
 	c, _ := NewClient(mc, l)
 
-	mi := new(MockIndexable)
-	mi.On("IndexName").Return("test-index").Times(1)
-
-	res, err := c.Search(map[string]interface{}{}, mi)
+	res, err := c.Search("test-index", map[string]interface{}{})
 
 	assert.Nil(t, res)
 	assert.NotNil(t, err)
@@ -544,84 +491,14 @@ func TestClient_Search_InvalidESRequestBody(t *testing.T) {
 
 	c, _ := NewClient(mc, l)
 
-	mi := new(MockIndexable)
-	mi.On("IndexName").Return("test-index").Times(1)
-
 	esReqBody := map[string]interface{}{
 		"term": func() {},
 	}
-	res, err := c.Search(esReqBody, mi)
+	res, err := c.Search("test-index", esReqBody)
 
 	assert.Nil(t, res)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "json: unsupported type: func()")
-}
-
-func TestClient_IndexExists(t *testing.T) {
-	tests := []struct {
-		scenario        string
-		esResponseError error
-		esResponseCode  int
-		wantExists      bool
-		wantError       error
-	}{
-		{
-			scenario:        "Index exists",
-			esResponseError: nil,
-			esResponseCode:  200,
-			wantExists:      true,
-			wantError:       nil,
-		},
-		{
-			scenario:        "Index does not exist",
-			esResponseError: nil,
-			esResponseCode:  404,
-			wantExists:      false,
-			wantError:       nil,
-		},
-		{
-			scenario:        "Unexpected failure",
-			esResponseError: errors.New("some ES error"),
-			esResponseCode:  500,
-			wantExists:      false,
-			wantError:       errors.New("some ES error"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.scenario, func(t *testing.T) {
-			mc := new(MockHttpClient)
-
-			l, hook := logrus_test.NewNullLogger()
-
-			c, err := NewClient(mc, l)
-
-			assert.IsType(t, &Client{}, c)
-			assert.Nil(t, err)
-
-			mi := new(MockIndexable)
-			mi.On("IndexName").Return("test-index").Times(2)
-
-			mcCall := mc.On("Do", mock.AnythingOfType("*http.Request"))
-			mcCall.RunFn = func(args mock.Arguments) {
-				req := args[0].(*http.Request)
-				assert.Equal(t, http.MethodHead, req.Method)
-				assert.Equal(t, os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/test-index", req.URL.String())
-			}
-			mcCall.Return(
-				&http.Response{
-					StatusCode: test.esResponseCode,
-				},
-				test.esResponseError,
-			)
-
-			exists, err := c.IndexExists(mi)
-
-			assert.Contains(t, hook.LastEntry().Message, "Checking index 'test-index' exists")
-			assert.Equal(t, test.wantExists, exists)
-			assert.Equal(t, test.wantError, err)
-		})
-	}
 }
 
 func TestBulkOp(t *testing.T) {

--- a/internal/cmd/index/elasticsearch.go
+++ b/internal/cmd/index/elasticsearch.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (r *Indexer) index(ctx context.Context, persons <-chan person.Person) (*Result, error) {
-	op := elasticsearch.NewBulkOp("person")
+	op := elasticsearch.NewBulkOp(r.indexName)
 	result := &Result{}
 
 	for p := range persons {

--- a/internal/cmd/index/elasticsearch_test.go
+++ b/internal/cmd/index/elasticsearch_test.go
@@ -28,7 +28,7 @@ func TestIndex(t *testing.T) {
 	client := &mockBulkClient{
 		result: elasticsearch.BulkResult{Successful: 1, Failed: 0},
 	}
-	r := &Indexer{es: client}
+	r := &Indexer{es: client, indexName: "person"}
 
 	p := person.Person{ID: i64(1), Firstname: "A"}
 

--- a/internal/cmd/index/index.go
+++ b/internal/cmd/index/index.go
@@ -17,18 +17,20 @@ type Logger interface {
 	Printf(string, ...interface{})
 }
 
-func New(conn *pgx.Conn, es BulkClient, logger Logger) *Indexer {
+func New(conn *pgx.Conn, es BulkClient, logger Logger, indexName string) *Indexer {
 	return &Indexer{
-		conn: conn,
-		es:   es,
-		log:  logger,
+		conn:      conn,
+		es:        es,
+		log:       logger,
+		indexName: indexName,
 	}
 }
 
 type Indexer struct {
-	conn *pgx.Conn
-	es   BulkClient
-	log  Logger
+	conn      *pgx.Conn
+	es        BulkClient
+	log       Logger
+	indexName string
 }
 
 func (r *Indexer) All(ctx context.Context, batchSize int) (*Result, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -95,7 +95,7 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 	suite.Nil(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
 
-	exists, err := suite.esClient.IndexExists(person.Person{})
+	exists, err := suite.esClient.IndexExists("person")
 	suite.False(exists, "Person index should not exist at this point")
 	suite.Nil(err)
 
@@ -108,7 +108,7 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 			continue
 		}
 
-		exists, err = suite.esClient.IndexExists(person.Person{})
+		exists, err = suite.esClient.IndexExists("person")
 		suite.True(exists, "Person index should exist at this point")
 		suite.Nil(err)
 
@@ -136,7 +136,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 
 	data, _ := ioutil.ReadAll(resp.Body)
 
-	suite.Equal(`{"successful":2,"failed":0}`, string(data))
+	suite.Equal(`{"successful":4,"failed":0}`, string(data))
 
 	testCases := []struct {
 		scenario         string

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,7 @@ import (
 type EndToEndTestSuite struct {
 	suite.Suite
 	testPeople []person.Person
-	esClient   elasticsearch.ClientInterface
+	esClient   *elasticsearch.Client
 	authHeader string
 }
 

--- a/person/index_handler_test.go
+++ b/person/index_handler_test.go
@@ -33,8 +33,9 @@ func (suite *IndexHandlerTestSuite) SetupTest() {
 	suite.logger, _ = test.NewNullLogger()
 	suite.esClient = new(elasticsearch.MockESClient)
 	suite.handler = &IndexHandler{
-		logger: suite.logger,
-		es:     suite.esClient,
+		logger:    suite.logger,
+		client:    suite.esClient,
+		indexName: "person-test",
 	}
 	suite.router = mux.NewRouter().Methods(http.MethodPost).Subrouter()
 	suite.router.Handle("/persons", suite.handler)
@@ -95,24 +96,33 @@ func (suite *IndexHandlerTestSuite) Test_InvalidIndexRequestBody() {
 func (suite *IndexHandlerTestSuite) Test_Index() {
 	reqBody := `{"persons":[{"id":13},{"id":14}]}`
 
+	call := 0
+
 	esCall := suite.esClient.On("DoBulk", mock.AnythingOfType("*elasticsearch.BulkOp"))
 	esCall.RunFn = func(args mock.Arguments) {
 		actual := args[0].(*elasticsearch.BulkOp)
 
 		var id1, id2 int64 = 13, 14
 
-		expected := elasticsearch.NewBulkOp("person")
-		expected.Index(13, Person{ID: &id1})
-		expected.Index(14, Person{ID: &id2})
-
-		suite.Equal(expected, actual)
+		if call == 0 {
+			expected := elasticsearch.NewBulkOp("person")
+			expected.Index(13, Person{ID: &id1})
+			expected.Index(14, Person{ID: &id2})
+			suite.Equal(expected, actual)
+			call++
+		} else {
+			expected := elasticsearch.NewBulkOp("person-test")
+			expected.Index(13, Person{ID: &id1})
+			expected.Index(14, Person{ID: &id2})
+			suite.Equal(expected, actual)
+		}
 	}
-	esCall.Return(elasticsearch.BulkResult{Successful: 2, Failed: 1}, errors.New("hmm")).Once()
+	esCall.Return(elasticsearch.BulkResult{Successful: 2, Failed: 1}, errors.New("hmm")).Twice()
 
 	suite.ServeRequest(http.MethodPost, "/persons", reqBody)
 
 	suite.Equal(http.StatusAccepted, suite.RespCode())
-	suite.Equal(`{"successful":2,"failed":1,"errors":["hmm"]}`, suite.RespBody())
+	suite.Equal(`{"successful":4,"failed":2,"errors":["hmm","hmm"]}`, suite.RespBody())
 }
 
 func TestIndexHandler(t *testing.T) {
@@ -122,7 +132,7 @@ func TestIndexHandler(t *testing.T) {
 func TestNewIndexHandler(t *testing.T) {
 	l, _ := test.NewNullLogger()
 
-	ih, err := NewIndexHandler(l)
+	ih, err := NewIndexHandler(l, "i")
 
 	assert.Nil(t, err)
 	assert.IsType(t, &IndexHandler{}, ih)

--- a/person/person.go
+++ b/person/person.go
@@ -1,7 +1,9 @@
 package person
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"opg-search-service/response"
 )
 
@@ -53,15 +55,6 @@ func (p Person) Id() int64 {
 	return val
 }
 
-func (p Person) IndexName() string {
-	return personIndexName
-}
-
-func (p Person) Json() string {
-	b, _ := json.Marshal(p)
-	return string(b)
-}
-
 func (p Person) Validate() []response.Error {
 	var errs []response.Error
 
@@ -75,8 +68,8 @@ func (p Person) Validate() []response.Error {
 	return errs
 }
 
-func (p Person) IndexConfig() map[string]interface{} {
-	return map[string]interface{}{
+func IndexConfig() (name string, config []byte, err error) {
+	personConfig := map[string]interface{}{
 		"settings": map[string]interface{}{
 			"number_of_shards":   1,
 			"number_of_replicas": 1,
@@ -213,4 +206,13 @@ func (p Person) IndexConfig() map[string]interface{} {
 			},
 		},
 	}
+
+	data, err := json.Marshal(personConfig)
+	if err != nil {
+		return "", nil, err
+	}
+
+	sum := sha256.Sum256(data)
+
+	return fmt.Sprintf("%s_%x", personIndexName, sum[:8]), data, err
 }

--- a/person/person_test.go
+++ b/person/person_test.go
@@ -1,10 +1,10 @@
 package person
 
 import (
-	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"opg-search-service/response"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPerson_Id(t *testing.T) {
@@ -31,17 +31,6 @@ func TestPerson_Id(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, test.expectedId, test.person.Id(), test.scenario)
 	}
-}
-
-func TestPerson_IndexName(t *testing.T) {
-	p := Person{}
-	assert.Equal(t, "person", p.IndexName())
-}
-
-func TestPerson_Json(t *testing.T) {
-	p := Person{}
-	res, _ := json.Marshal(p)
-	assert.Equal(t, string(res), p.Json())
 }
 
 func TestPerson_Validate(t *testing.T) {
@@ -87,10 +76,4 @@ func TestPerson_Validate(t *testing.T) {
 		errs := test.person.Validate()
 		assert.Equal(t, test.expectedErrs, errs, test.scenario)
 	}
-}
-
-func TestPerson_IndexConfig(t *testing.T) {
-	ic := Person{}.IndexConfig()
-	assert.IsType(t, map[string]interface{}{}, ic)
-	assert.NotEmpty(t, ic)
 }

--- a/person/search_handler_test.go
+++ b/person/search_handler_test.go
@@ -117,10 +117,11 @@ func (suite *SearchHandlerTestSuite) Test_ESReturnsUnexpectedError() {
 func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 	reqBody := `{"term":"testTerm","from":10,"size":20,"person_types":["type1","type2"]}`
 
-	esCall := suite.esClient.On("Search", mock.Anything, mock.AnythingOfType("Person"))
+	esCall := suite.esClient.On("Search", "person", mock.Anything)
 	esCall.RunFn = func(args mock.Arguments) {
-		esReqBody := args[0].(map[string]interface{})
-		dataType := args[1].(Person)
+		indexName := args[0].(string)
+		esReqBody := args[1].(map[string]interface{})
+
 		expectedEsReqBody := map[string]interface{}{
 			"size": 20,
 			"from": 10,
@@ -168,7 +169,7 @@ func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 			},
 		}
 		suite.Equal(expectedEsReqBody, esReqBody)
-		suite.IsType(Person{}, dataType)
+		suite.IsType("person", indexName)
 	}
 
 	result := &elasticsearch.SearchResult{


### PR DESCRIPTION
I ended up refactoring things to make it easier to pass around a name for the index. 
- `IndexConfig()` is now a function instead of a method on `person.Person`, and returns the name for the index too. It has always seemed a bit daft to me having it on `person.Person` when it didn't use any fields or other methods.
- I moved the create index logic onto `elasticsearch.Client` so it didn't need to be duplicated between the CLI command and `main`.

Also realised that we'd want the `index` command to do `person` by default, so added a `--hash` flag to switch when running on AWS.