### PR TITLE
Stop logging search term

### DIFF
--- a/person/search_request.go
+++ b/person/search_request.go
@@ -42,7 +42,6 @@ func CreateSearchRequestFromRequest(r *http.Request) (*searchRequest, error) {
 
 func (sr *searchRequest) sanitise() {
 	re := regexp.MustCompile(`[^’'\p{L}\d\-.@ \/_]`)
-	log.Println(re.ReplaceAllString(sr.Term, ""))
 	sr.Term = strings.TrimSpace(re.ReplaceAllString(sr.Term, ""))
 
 	for i, val := range sr.PersonTypes {


### PR DESCRIPTION
It isn't useful to us and can contain confidential information, such as tying a person to a case ID, or to an address #patch