### PR TITLE
Revert "VEGA-1161 Only use index containing hash"

### DIFF
--- a/cli/create_indices.go
+++ b/cli/create_indices.go
@@ -44,6 +44,10 @@ func (c *createIndices) Run(args []string) error {
 		return err
 	}
 
+	if err := c.esClient.CreateIndex("person", c.indexConfig, *force); err != nil {
+		return err
+	}
+
 	if err := c.esClient.CreateIndex(c.indexName, c.indexConfig, *force); err != nil {
 		return err
 	}

--- a/cli/create_indices_test.go
+++ b/cli/create_indices_test.go
@@ -79,7 +79,7 @@ func TestCreateIndicesRunErrorInFirst(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.scenario, func(t *testing.T) {
 			esClient := new(elasticsearch.MockESClient)
-			esClient.On("CreateIndex", "person-test", indexConfig, tc.force).Times(1).Return(tc.error)
+			esClient.On("CreateIndex", "person", indexConfig, tc.force).Times(1).Return(tc.error)
 
 			ci := createIndices{
 				esClient:    esClient,

--- a/cli/index.go
+++ b/cli/index.go
@@ -52,6 +52,7 @@ func (c *indexCommand) Run(args []string) error {
 	to := flagset.Int("to", 100, "id to index to")
 	batchSize := flagset.Int("batch-size", 10000, "batch size to read from db")
 	fromDate := flagset.String("from-date", "", "index all records updated from this date")
+	hash := flagset.Bool("hash", false, "index to the person_hash index")
 
 	if err := flagset.Parse(args); err != nil {
 		return err
@@ -74,7 +75,12 @@ func (c *indexCommand) Run(args []string) error {
 		return err
 	}
 
-	indexer := index.New(conn, c.esClient, c.logger, c.indexName)
+	indexName := "person"
+	if *hash {
+		indexName = c.indexName
+	}
+
+	indexer := index.New(conn, c.esClient, c.logger, indexName)
 
 	fromTime, err := time.Parse(time.RFC3339, *fromDate)
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ func main() {
 		l.Fatal(err)
 	}
 
+	if err := esClient.CreateIndex("person", personConfig, false); err != nil {
+		l.Fatal(err)
+	}
+
 	if err := esClient.CreateIndex(personName, personConfig, false); err != nil {
 		l.Fatal(err)
 	}
@@ -299,7 +303,7 @@ func main() {
 	//     description: Unexpected error occurred
 	postRouter.Handle("/persons", iph)
 
-	sph, err := person.NewSearchHandler(l, personName)
+	sph, err := person.NewSearchHandler(l)
 	if err != nil {
 		l.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -95,9 +95,7 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 	suite.Nil(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
 
-	indexName, _, _ := person.IndexConfig()
-
-	exists, err := suite.esClient.IndexExists(indexName)
+	exists, err := suite.esClient.IndexExists("person")
 	suite.False(exists, "Person index should not exist at this point")
 	suite.Nil(err)
 
@@ -110,7 +108,7 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 			continue
 		}
 
-		exists, err = suite.esClient.IndexExists(indexName)
+		exists, err = suite.esClient.IndexExists("person")
 		suite.True(exists, "Person index should exist at this point")
 		suite.Nil(err)
 
@@ -138,7 +136,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 
 	data, _ := ioutil.ReadAll(resp.Body)
 
-	suite.Equal(`{"successful":2,"failed":0}`, string(data))
+	suite.Equal(`{"successful":4,"failed":0}`, string(data))
 
 	testCases := []struct {
 		scenario         string

--- a/person/index_handler.go
+++ b/person/index_handler.go
@@ -67,6 +67,10 @@ func (i *IndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	response := &indexResponse{}
 
+	if err := i.doIndex(personIndexName, response, req.Persons); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	if err := i.doIndex(i.indexName, response, req.Persons); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}

--- a/person/index_handler_test.go
+++ b/person/index_handler_test.go
@@ -96,23 +96,33 @@ func (suite *IndexHandlerTestSuite) Test_InvalidIndexRequestBody() {
 func (suite *IndexHandlerTestSuite) Test_Index() {
 	reqBody := `{"persons":[{"id":13},{"id":14}]}`
 
+	call := 0
+
 	esCall := suite.esClient.On("DoBulk", mock.AnythingOfType("*elasticsearch.BulkOp"))
 	esCall.RunFn = func(args mock.Arguments) {
 		actual := args[0].(*elasticsearch.BulkOp)
 
 		var id1, id2 int64 = 13, 14
 
-		expected := elasticsearch.NewBulkOp("person-test")
-		expected.Index(13, Person{ID: &id1})
-		expected.Index(14, Person{ID: &id2})
-		suite.Equal(expected, actual)
+		if call == 0 {
+			expected := elasticsearch.NewBulkOp("person")
+			expected.Index(13, Person{ID: &id1})
+			expected.Index(14, Person{ID: &id2})
+			suite.Equal(expected, actual)
+			call++
+		} else {
+			expected := elasticsearch.NewBulkOp("person-test")
+			expected.Index(13, Person{ID: &id1})
+			expected.Index(14, Person{ID: &id2})
+			suite.Equal(expected, actual)
+		}
 	}
 	esCall.Return(elasticsearch.BulkResult{Successful: 2, Failed: 1}, errors.New("hmm")).Twice()
 
 	suite.ServeRequest(http.MethodPost, "/persons", reqBody)
 
 	suite.Equal(http.StatusAccepted, suite.RespCode())
-	suite.Equal(`{"successful":2,"failed":1,"errors":["hmm"]}`, suite.RespBody())
+	suite.Equal(`{"successful":4,"failed":2,"errors":["hmm","hmm"]}`, suite.RespBody())
 }
 
 func TestIndexHandler(t *testing.T) {

--- a/person/person.go
+++ b/person/person.go
@@ -7,6 +7,8 @@ import (
 	"opg-search-service/response"
 )
 
+const personIndexName = "person"
+
 type Person struct {
 	ID               *int64              `json:"id"`
 	UID              string              `json:"uId"`
@@ -212,5 +214,5 @@ func IndexConfig() (name string, config []byte, err error) {
 
 	sum := sha256.Sum256(data)
 
-	return fmt.Sprintf("person_%x", sum[:8]), data, err
+	return fmt.Sprintf("%s_%x", personIndexName, sum[:8]), data, err
 }

--- a/person/search_handler.go
+++ b/person/search_handler.go
@@ -16,12 +16,11 @@ type SearchClient interface {
 }
 
 type SearchHandler struct {
-	logger    *logrus.Logger
-	es        SearchClient
-	indexName string
+	logger *logrus.Logger
+	es     SearchClient
 }
 
-func NewSearchHandler(logger *logrus.Logger, indexName string) (*SearchHandler, error) {
+func NewSearchHandler(logger *logrus.Logger) (*SearchHandler, error) {
 	client, err := elasticsearch.NewClient(&http.Client{}, logger)
 	if err != nil {
 		logger.Println(err)
@@ -29,9 +28,8 @@ func NewSearchHandler(logger *logrus.Logger, indexName string) (*SearchHandler, 
 	}
 
 	return &SearchHandler{
-		logger:    logger,
-		es:        client,
-		indexName: indexName,
+		logger,
+		client,
 	}, nil
 }
 
@@ -94,7 +92,7 @@ func (s SearchHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		esReqBody["size"] = req.Size
 	}
 
-	result, err := s.es.Search(s.indexName, esReqBody)
+	result, err := s.es.Search(personIndexName, esReqBody)
 	if err != nil {
 		s.logger.Println(err.Error())
 		response.WriteJSONError(rw, "request", "Person search caused an unexpected error", http.StatusInternalServerError)

--- a/person/search_handler_test.go
+++ b/person/search_handler_test.go
@@ -35,9 +35,8 @@ func (suite *SearchHandlerTestSuite) SetupTest() {
 	suite.logger, _ = test.NewNullLogger()
 	suite.esClient = new(elasticsearch.MockESClient)
 	suite.handler = &SearchHandler{
-		logger:    suite.logger,
-		es:        suite.esClient,
-		indexName: "person-test",
+		logger: suite.logger,
+		es:     suite.esClient,
 	}
 	suite.router = mux.NewRouter().Methods(http.MethodPost).Subrouter()
 	suite.router.Handle("/persons/search", suite.handler)
@@ -118,7 +117,7 @@ func (suite *SearchHandlerTestSuite) Test_ESReturnsUnexpectedError() {
 func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 	reqBody := `{"term":"testTerm","from":10,"size":20,"person_types":["type1","type2"]}`
 
-	esCall := suite.esClient.On("Search", "person-test", mock.Anything)
+	esCall := suite.esClient.On("Search", "person", mock.Anything)
 	esCall.RunFn = func(args mock.Arguments) {
 		indexName := args[0].(string)
 		esReqBody := args[1].(map[string]interface{})
@@ -213,7 +212,7 @@ func TestSearchHandler(t *testing.T) {
 func TestNewSearchHandler(t *testing.T) {
 	l, _ := test.NewNullLogger()
 
-	sh, err := NewSearchHandler(l, "person-test")
+	sh, err := NewSearchHandler(l)
 
 	assert.Nil(t, err)
 	assert.IsType(t, &SearchHandler{}, sh)


### PR DESCRIPTION
Reverts ministryofjustice/opg-search-service#145

Because the index in the code doesn't match the existing index we need to undo this change while the differences are figured out