### PR TITLE
Create an alias when force-creating the index #patch

### DIFF
--- a/internal/elasticsearch/client_mock.go
+++ b/internal/elasticsearch/client_mock.go
@@ -20,3 +20,13 @@ func (m *MockESClient) CreateIndex(name string, config []byte, force bool) error
 	args := m.Called(name, config, force)
 	return args.Error(0)
 }
+
+func (m *MockESClient) ResolveAlias(alias string) (string, error) {
+	args := m.Called(alias)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockESClient) CreateAlias(alias string, index string) error {
+	args := m.Called(alias, index)
+	return args.Error(0)
+}


### PR DESCRIPTION
When forced to delete and recreate an index, also create the alias if it's missing.

Otherwise, the alias gets removed and the next indexing request will auto-create a `person` index with incorrect configuration.