### PR TITLE
Force deletion when removing a person

### DIFF
--- a/internal/remove/handler.go
+++ b/internal/remove/handler.go
@@ -46,6 +46,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"uId": uid,
 			},
 		},
+		"conflicts": "proceed",
+		"max_docs":  1,
 	}
 
 	result, err := h.client.Delete(h.indices, requestBody)

--- a/internal/remove/handler_test.go
+++ b/internal/remove/handler_test.go
@@ -115,6 +115,8 @@ func (suite *DeleteHandlerTestSuite) Test_Delete() {
 				"uId": "7000-9000-9201",
 			},
 		},
+		"conflicts": "proceed",
+		"max_docs":  1,
 	}
 
 	result := &elasticsearch.DeleteResult{


### PR DESCRIPTION
If Elasticsearch detects a conflict (because the person has been updated extremely recently) then force the deletion rather than letting ES block it.

For VEGA-1225 #patch