### PR TITLE
VEGA-1372 Allow searching postcodes with and without spaces

### DIFF
--- a/internal/person/person.go
+++ b/internal/person/person.go
@@ -71,135 +71,77 @@ func (p Person) Validate() []response.Error {
 }
 
 func IndexConfig() (name string, config []byte, err error) {
+	textField := map[string]interface{}{"type": "text"}
+	keywordField := map[string]interface{}{"type": "keyword"}
+
 	personConfig := map[string]interface{}{
 		"settings": map[string]interface{}{
 			"number_of_shards":   1,
 			"number_of_replicas": 1,
 			"refresh_interval":   "1s",
 			"analysis": map[string]interface{}{
+				"filter": map[string]interface{}{
+					"whitespace_remove": map[string]interface{}{
+						"type":        "pattern_replace",
+						"pattern":     " ",
+						"replacement": "",
+					},
+				},
 				"analyzer": map[string]interface{}{
-					"quick_search": map[string]interface{}{
-						"type":      "custom",
+					"default": map[string]interface{}{
 						"tokenizer": "whitespace",
-						"filter": []string{
-							"asciifolding",
-							"lowercase",
-						},
+						"filter":    []string{"asciifolding", "lowercase"},
+					},
+					"no_space_analyzer": map[string]interface{}{
+						"tokenizer": "keyword",
+						"filter":    []string{"whitespace_remove", "lowercase"},
 					},
 				},
 			},
 		},
 		"mappings": map[string]interface{}{
 			"properties": map[string]interface{}{
-				"searchable": map[string]interface{}{
-					"type":     "text",
-					"analyzer": "quick_search",
-				},
-				"uId": map[string]interface{}{
-					"type":    "keyword",
-					"copy_to": "searchable",
-				},
-				"normalizedUid": map[string]interface{}{
-					"type":    "text",
-					"index":   false,
-					"copy_to": "searchable",
-				},
-				"caseRecNumber": map[string]interface{}{
-					"type":    "keyword",
-					"copy_to": "searchable",
-				},
-				"deputyNumber": map[string]interface{}{
-					"type":    "keyword",
-					"copy_to": "searchable",
-				},
-				"personType": map[string]interface{}{
-					"type": "keyword",
-				},
-				"dob": map[string]interface{}{
-					"type":     "text",
-					"analyzer": "whitespace",
-					"copy_to":  "searchable",
-				},
-				"email": map[string]interface{}{
-					"type": "text",
-				},
-				"firstname": map[string]interface{}{
-					"type":    "text",
-					"copy_to": "searchable",
-				},
-				"middlenames": map[string]interface{}{
-					"type":    "text",
-					"copy_to": "searchable",
-				},
-				"surname": map[string]interface{}{
-					"type":    "keyword",
-					"copy_to": "searchable",
-				},
-				"companyName": map[string]interface{}{
-					"type":    "text",
-					"copy_to": "searchable",
-				},
-				"className": map[string]interface{}{
-					"type":    "text",
-					"copy_to": "searchable",
-				},
+				"uId":           keywordField,
+				"normalizedUid": keywordField,
+				"caseRecNumber": keywordField,
+				"deputyNumber":  keywordField,
+				"personType":    keywordField,
+				"dob":           textField,
+				"email":         textField,
+				"firstname":     textField,
+				"middlenames":   textField,
+				"surname":       textField,
+				"companyName":   textField,
+				"className":     textField,
 				"phoneNumbers": map[string]interface{}{
 					"properties": map[string]interface{}{
-						"phoneNumber": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
+						"phoneNumber": keywordField,
 					},
 				},
 				"addresses": map[string]interface{}{
 					"properties": map[string]interface{}{
-						"addressLines": map[string]interface{}{
-							"type":    "text",
-							"copy_to": "searchable",
-						},
+						"addressLines": textField,
 						"postcode": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
+							"type":     "text",
+							"analyzer": "no_space_analyzer",
+							"fields": map[string]interface{}{
+								"keyword": keywordField,
+							},
 						},
 					},
 				},
 				"cases": map[string]interface{}{
 					"properties": map[string]interface{}{
-						"uId": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
-						"normalizedUid": map[string]interface{}{
-							"type":    "text",
-							"index":   false,
-							"copy_to": "searchable",
-						},
-						"caseRecNumber": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
-						"onlineLpaId": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
-						"batchId": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
-						"caseType": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
-						"caseSubtype": map[string]interface{}{
-							"type":    "keyword",
-							"copy_to": "searchable",
-						},
+						"uId":           keywordField,
+						"normalizedUid": keywordField,
+						"caseRecNumber": keywordField,
+						"onlineLpaId":   keywordField,
+						"batchId":       keywordField,
+						"caseType":      keywordField,
+						"caseSubtype":   keywordField,
 					},
 				},
-				"organisationName": map[string]interface{}{
-					"type":    "text",
-					"copy_to": "searchable",
-				},
+				"organisationName": textField,
 			},
 		},
 	}

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -16,17 +16,10 @@ func PrepareQueryForFirm(req *Request) map[string]interface{} {
 func PrepareQueryForPerson(req *Request) map[string]interface{} {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": map[string]interface{}{
-					"simple_query_string": map[string]interface{}{
-						"query": req.Term,
-						"fields": []string{
-							"searchable",
-							"caseRecNumber",
-						},
-						"default_operator": "AND",
-					},
-				},
+			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
+				"query":  req.Term,
+				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 	}
@@ -38,8 +31,9 @@ func PrepareQueryForFirmAndPerson(req *Request) map[string]interface{} {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
 				"query":  req.Term,
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 	}

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -1,11 +1,21 @@
 package search
 
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	firmFields   = []string{"firmName", "firmNumber"}
+	personFields = []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"}
+)
+
 func PrepareQueryForFirm(req *Request) map[string]interface{} {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
 				"query":  req.Term,
-				"fields": []string{"firmName", "firmNumber"},
+				"fields": firmFields,
 			},
 		},
 	}
@@ -14,17 +24,36 @@ func PrepareQueryForFirm(req *Request) map[string]interface{} {
 }
 
 func PrepareQueryForPerson(req *Request) map[string]interface{} {
-	body := map[string]interface{}{
-		"query": map[string]interface{}{
-			"multi_match": map[string]interface{}{
-				"type":   "most_fields",
-				"query":  req.Term,
-				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
-			},
+	postcode := postcodeTerm(req.Term)
+
+	multiMatch := map[string]interface{}{
+		"multi_match": map[string]interface{}{
+			"type":   "most_fields",
+			"query":  req.Term,
+			"fields": personFields,
 		},
 	}
 
-	return withDefaults(req, body)
+	if postcode == "" {
+		return withDefaults(req, map[string]interface{}{
+			"query": multiMatch,
+		})
+	}
+
+	return withDefaults(req, map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"should": []map[string]interface{}{
+					multiMatch,
+					{
+						"match": map[string]interface{}{
+							"addresses.postcode": map[string]interface{}{"query": postcode},
+						},
+					},
+				},
+			},
+		},
+	})
 }
 
 func PrepareQueryForFirmAndPerson(req *Request) map[string]interface{} {
@@ -33,12 +62,23 @@ func PrepareQueryForFirmAndPerson(req *Request) map[string]interface{} {
 			"multi_match": map[string]interface{}{
 				"type":   "most_fields",
 				"query":  req.Term,
-				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
+				"fields": append(personFields, firmFields...),
 			},
 		},
 	}
 
 	return withDefaults(req, body)
+}
+
+func postcodeTerm(term string) string {
+	re, _ := regexp.Compile(`(gir 0a{2})|((([a-z][0-9]{1,2})|(([a-z][a-hj-y][0-9]{1,2})|(([a-z][0-9][a-z])|([a-z][a-hj-y][0-9][a-z]?))))\s?[0-9][a-z]{2})`)
+	matches := re.FindStringSubmatch(strings.ToLower(term))
+
+	if len(matches) > 0 {
+		return matches[0]
+	}
+
+	return ""
 }
 
 func withDefaults(req *Request, body map[string]interface{}) map[string]interface{} {

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -94,6 +94,41 @@ func TestPrepareQueryForPerson(t *testing.T) {
 	}, body)
 }
 
+func TestPrepareQueryForPersonWithPostcode(t *testing.T) {
+	req := &Request{
+		Term: "apples ng15ab",
+		From: 123,
+	}
+
+	body := PrepareQueryForPerson(req)
+
+	assert.Equal(t, map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"should": []map[string]interface{}{
+					{"multi_match": map[string]interface{}{
+						"type":   "most_fields",
+						"query":  "apples ng15ab",
+						"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
+					}},
+					{"match": map[string]interface{}{
+						"addresses.postcode": map[string]interface{}{"query": "ng15ab"},
+					}},
+				},
+			},
+		},
+		"aggs": map[string]interface{}{
+			"personType": map[string]interface{}{
+				"terms": map[string]string{
+					"field": "personType",
+				},
+			},
+		},
+		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
+		"from":        123,
+	}, body)
+}
+
 func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 	req := &Request{
 		Term:        "apples",
@@ -141,7 +176,7 @@ func TestPrepareQueryForFirmAndPerson(t *testing.T) {
 			"multi_match": map[string]interface{}{
 				"type":   "most_fields",
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
+				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName", "firmName", "firmNumber"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -171,7 +206,7 @@ func TestPrepareQueryForFirmAndPersonWithOptions(t *testing.T) {
 			"multi_match": map[string]interface{}{
 				"type":   "most_fields",
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
+				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName", "firmName", "firmNumber"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -188,4 +223,37 @@ func TestPrepareQueryForFirmAndPersonWithOptions(t *testing.T) {
 		"from": 123,
 		"size": 10,
 	}, body)
+}
+
+func TestPostcodeTerm(t *testing.T) {
+	testcases := map[string]struct {
+		term             string
+		expectedPostcode string
+	}{
+		"no postcode": {
+			term: "26 some street",
+		},
+		"short postcode": {
+			term:             "26 some street s11aa john",
+			expectedPostcode: "s11aa",
+		},
+		"long postcode": {
+			term:             "26 some street ng11aa john",
+			expectedPostcode: "ng11aa",
+		},
+		"short postcode with space": {
+			term:             "26 some street s1 1aa john",
+			expectedPostcode: "s1 1aa",
+		},
+		"long postcode with space": {
+			term:             "26 some street ng1 1aa john",
+			expectedPostcode: "ng1 1aa",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedPostcode, postcodeTerm(tc.term))
+		})
+	}
 }

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -76,17 +76,10 @@ func TestPrepareQueryForPerson(t *testing.T) {
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": map[string]interface{}{
-					"simple_query_string": map[string]interface{}{
-						"query": "apples",
-						"fields": []string{
-							"searchable",
-							"caseRecNumber",
-						},
-						"default_operator": "AND",
-					},
-				},
+			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
+				"query":  "apples",
+				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -113,17 +106,10 @@ func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
-			"bool": map[string]interface{}{
-				"must": map[string]interface{}{
-					"simple_query_string": map[string]interface{}{
-						"query": "apples",
-						"fields": []string{
-							"searchable",
-							"caseRecNumber",
-						},
-						"default_operator": "AND",
-					},
-				},
+			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
+				"query":  "apples",
+				"fields": []string{"uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -153,8 +139,9 @@ func TestPrepareQueryForFirmAndPerson(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -182,8 +169,9 @@ func TestPrepareQueryForFirmAndPersonWithOptions(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
+				"type":   "most_fields",
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "uId", "normalizedUid", "caseRecNumber", "deputyNumber", "dob", "firstname", "middlenames", "surname^3", "companyName", "className", "phoneNumbers.phoneNumber", "addresses.addressLines", "addresses.postcode", "cases.uId", "cases.normalizedUid", "cases.caseRecNumber", "cases.onlineLpaId", "cases.batchId", "cases.caseType", "cases.caseSubtype", "organisationName"},
 			},
 		},
 		"aggs": map[string]interface{}{

--- a/internal/search/search_request_test.go
+++ b/internal/search/search_request_test.go
@@ -57,12 +57,14 @@ func TestCreateSearchRequestFromRequest(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		req := http.Request{
-			Body: ioutil.NopCloser(bytes.NewReader([]byte(test.reqJson))),
-		}
-		sr, err := parseSearchRequest(&req)
+		t.Run(test.scenario, func(t *testing.T) {
+			req := http.Request{
+				Body: ioutil.NopCloser(bytes.NewReader([]byte(test.reqJson))),
+			}
+			sr, err := parseSearchRequest(&req)
 
-		assert.Equal(t, test.err, err, test.scenario)
-		assert.Equal(t, test.expectedRequest, sr, test.scenario)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.expectedRequest, sr)
+		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -64,7 +64,7 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 			Persontype: "Type0",
 			Dob:        "01/02/1990",
 			Addresses: []person.PersonAddress{{
-				Postcode: "NG1 2CD",
+				Postcode: "NG12CD",
 			}},
 		},
 		{
@@ -191,7 +191,27 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 	}{
 		{
 			scenario: "search by surname",
-			term:     suite.testPeople[1].Surname,
+			term:     "Doe1",
+			expectedResponse: func() search.Response {
+				hit, _ := json.Marshal(suite.testPeople[1])
+
+				return search.Response{
+					Results: []json.RawMessage{hit},
+					Aggregations: map[string]map[string]int{
+						"personType": {
+							"Type1": 1,
+						},
+					},
+					Total: search.ResponseTotal{
+						Count: 1,
+						Exact: true,
+					},
+				}
+			},
+		},
+		{
+			scenario: "search by lowercase surname",
+			term:     "doe1",
 			expectedResponse: func() search.Response {
 				hit, _ := json.Marshal(suite.testPeople[1])
 
@@ -230,8 +250,68 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			},
 		},
 		{
-			scenario: "search by postcode",
+			scenario: "search postcode by postcode",
+			term:     "NG1 1AB",
+			expectedResponse: func() search.Response {
+				hit, _ := json.Marshal(suite.testPeople[1])
+
+				return search.Response{
+					Results: []json.RawMessage{hit},
+					Aggregations: map[string]map[string]int{
+						"personType": {
+							"Type1": 1,
+						},
+					},
+					Total: search.ResponseTotal{
+						Count: 1,
+						Exact: true,
+					},
+				}
+			},
+		},
+		{
+			scenario: "search postcode by spaceless postcode",
+			term:     "NG11AB",
+			expectedResponse: func() search.Response {
+				hit, _ := json.Marshal(suite.testPeople[1])
+
+				return search.Response{
+					Results: []json.RawMessage{hit},
+					Aggregations: map[string]map[string]int{
+						"personType": {
+							"Type1": 1,
+						},
+					},
+					Total: search.ResponseTotal{
+						Count: 1,
+						Exact: true,
+					},
+				}
+			},
+		},
+		{
+			scenario: "search spaceless postcode by postcode",
 			term:     "NG1 2CD",
+			expectedResponse: func() search.Response {
+				hit, _ := json.Marshal(suite.testPeople[0])
+
+				return search.Response{
+					Results: []json.RawMessage{hit},
+					Aggregations: map[string]map[string]int{
+						"personType": {
+							"Type0": 1,
+						},
+					},
+					Total: search.ResponseTotal{
+						Count: 1,
+						Exact: true,
+					},
+				}
+			},
+		},
+		{
+			scenario: "search spaceless postcode by spaceless postcode",
+			term:     "NG12CD",
 			expectedResponse: func() search.Response {
 				hit, _ := json.Marshal(suite.testPeople[0])
 


### PR DESCRIPTION
This does change searches on other fields too. It returns "fuzzier" matches (which I think is what we want to happen anyway). For example, if we have:

```
| John Doe | 123 Fake Street | 
| Jane Doe | 123 Other Street |
```

A search for `123 Fake Street` will return both, but ordered with John first as that is the best match, the previous behaviour would be to return only John.