### PR TITLE
Support passthrough queries on person search

### DIFF
--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -14,6 +14,10 @@ func PrepareQueryForFirm(req *Request) map[string]interface{} {
 }
 
 func PrepareQueryForPerson(req *Request) map[string]interface{} {
+	if req.Prepared != nil {
+		return req.Prepared
+	}
+
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -142,6 +142,20 @@ func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 	}, body)
 }
 
+func TestPrepareQueryForPersonAlreadyPrepared(t *testing.T) {
+	req := &Request{
+		Prepared: map[string]interface{}{
+			"query": "some prepared query",
+		},
+	}
+
+	body := PrepareQueryForPerson(req)
+
+	assert.Equal(t, map[string]interface{}{
+		"query": "some prepared query",
+	}, body)
+}
+
 func TestPrepareQueryForFirmAndPerson(t *testing.T) {
 	req := &Request{
 		Term: "apples",

--- a/internal/search/search_request.go
+++ b/internal/search/search_request.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Request struct {
-	Term        string   `json:"term"`
-	Size        int      `json:"size,omitempty"`
-	From        int      `json:"from"`
-	PersonTypes []string `json:"person_types"`
+	Term        string                 `json:"term"`
+	Size        int                    `json:"size,omitempty"`
+	From        int                    `json:"from"`
+	PersonTypes []string               `json:"person_types"`
+	Prepared    map[string]interface{} `json:"prepared"`
 }
 
 func parseSearchRequest(r *http.Request) (*Request, error) {
@@ -33,7 +34,7 @@ func parseSearchRequest(r *http.Request) (*Request, error) {
 
 	req.sanitise()
 
-	if req.Term == "" {
+	if req.Term == "" && req.Prepared == nil {
 		return nil, errors.New("search term is required and cannot be empty")
 	}
 

--- a/internal/search/search_request_test.go
+++ b/internal/search/search_request_test.go
@@ -42,6 +42,14 @@ func TestCreateSearchRequestFromRequest(t *testing.T) {
 			nil,
 		},
 		{
+			"create from a prepared request",
+			`{"prepared":{"query":"some prepared query"}}`,
+			nil,
+			&Request{
+				Prepared: map[string]interface{}{"query": "some prepared query"},
+			},
+		},
+		{
 			"created request is sanitised",
 			`{"term":"R'ené_8 D’!Eath-Smi/the()","size":1,"from":2,"person_types":["firm","person"]}`,
 			nil,


### PR DESCRIPTION
Instead of providing a term and letting search-service create the query, requests can include a prepared query that is passed straight through to Elasticsearch

For VEGA-1539