### PR TITLE
VEGA Omit aggregations when empty

### DIFF
--- a/internal/search/response.go
+++ b/internal/search/response.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type Response struct {
 	Results      []json.RawMessage         `json:"results"`
-	Aggregations map[string]map[string]int `json:"aggregations"`
+	Aggregations map[string]map[string]int `json:"aggregations,omitempty"`
 	Total        ResponseTotal             `json:"total"`
 }
 


### PR DESCRIPTION
Added `omitempty` json tag to aggregations because it returns an array when empty but a map when results making it tricky to decode into a struct