### PR TITLE
Innocous change to config will trigger a new ES index

### DIFF
--- a/internal/person/person.go
+++ b/internal/person/person.go
@@ -120,6 +120,10 @@ func IndexConfig() (name string, config []byte, err error) {
 				"othernames":    searchableTextField,
 				"companyName":   searchableTextField,
 				"className":     searchableTextField,
+				"clientSource": map[string]interface{}{
+					"type":  "text",
+					"index": false,
+				},
 				"phoneNumbers": map[string]interface{}{
 					"properties": map[string]interface{}{
 						"phoneNumber": searchableKeywordField,


### PR DESCRIPTION
Background:
Bug SW-6348 will be fixed with an ElasticSearch  re-index. Ran via ECS commands on Adhoc ok

The favoured way to trigger an ElasticSearch re-index on prod is to make an ‘innocuous change’ to the go config, which tricks ES into building a new index when it sees the different hash.

Adding whitespace to this file doesn’t trigger a new hash but adding another field as per this PR works... not sure if it's overkill though