### PR TITLE
VEGA-1576-cancelled-requests-bug

### DIFF
--- a/internal/cmd/cleanup_indices_test.go
+++ b/internal/cmd/cleanup_indices_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ministryofjustice/opg-search-service/internal/firm"
@@ -14,18 +15,18 @@ type mockCleanupIndicesClient struct {
 	mock.Mock
 }
 
-func (m *mockCleanupIndicesClient) ResolveAlias(alias string) (string, error) {
-	args := m.Called(alias)
+func (m *mockCleanupIndicesClient) ResolveAlias(ctx context.Context, alias string) (string, error) {
+	args := m.Called(ctx, alias)
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockCleanupIndicesClient) Indices(term string) ([]string, error) {
-	args := m.Called(term)
+func (m *mockCleanupIndicesClient) Indices(ctx context.Context, term string) ([]string, error) {
+	args := m.Called(ctx, term)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockCleanupIndicesClient) DeleteIndex(index string) error {
-	args := m.Called(index)
+func (m *mockCleanupIndicesClient) DeleteIndex(ctx context.Context, index string) error {
+	args := m.Called(ctx, index)
 	return args.Error(0)
 }
 
@@ -34,26 +35,26 @@ func TestCleanupIndices(t *testing.T) {
 	client := &mockCleanupIndicesClient{}
 
 	client.
-		On("ResolveAlias", person.AliasName).
+		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_something", nil)
 
 	client.
-		On("ResolveAlias", firm.AliasName).
+		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_something", nil)
 
 	client.
-		On("Indices", "person_*").
+		On("Indices", mock.Anything, "person_*").
 		Return([]string{"person_xyz", "person_something", "person_abc"}, nil)
 
 	client.
-		On("Indices", "firm_*").
+		On("Indices", mock.Anything, "firm_*").
 		Return([]string{"firm_xyz", "firm_something", "firm_abc"}, nil)
 
-	client.On("DeleteIndex", "person_xyz").Return(nil).Once()
-	client.On("DeleteIndex", "person_abc").Return(nil).Once()
+	client.On("DeleteIndex", mock.Anything, "person_xyz").Return(nil).Once()
+	client.On("DeleteIndex", mock.Anything, "person_abc").Return(nil).Once()
 
-	client.On("DeleteIndex", "firm_xyz").Return(nil).Once()
-	client.On("DeleteIndex", "firm_abc").Return(nil).Once()
+	client.On("DeleteIndex", mock.Anything, "firm_xyz").Return(nil).Once()
+	client.On("DeleteIndex", mock.Anything, "firm_abc").Return(nil).Once()
 
 	command := NewCleanupIndices(l, client, map[string][]byte{"firm_something": indexConfig, "person_something": indexConfig})
 	assert.Nil(t, command.Run([]string{}))
@@ -64,19 +65,19 @@ func TestCleanupIndicesWhenAliasNotCurrent(t *testing.T) {
 	client := &mockCleanupIndicesClient{}
 
 	client.
-		On("ResolveAlias", person.AliasName).
+		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_xyz", nil)
 
 	client.
-		On("ResolveAlias", firm.AliasName).
+		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_xyz", nil)
 
 	client.
-		On("Indices", "person_*").
+		On("Indices", mock.Anything, "person_*").
 		Return([]string{"person_xyz", "person_something", "person_abc"}, nil)
 
 	client.
-		On("Indices", "firm_*").
+		On("Indices", mock.Anything, "firm_*").
 		Return([]string{"firm_xyz", "firm_something", "firm_abc"}, nil)
 
 	command := NewCleanupIndices(l, client, map[string][]byte{"firm_something": indexConfig, "person_something": indexConfig})
@@ -88,19 +89,19 @@ func TestCleanupIndicesExplain(t *testing.T) {
 	client := &mockCleanupIndicesClient{}
 
 	client.
-		On("ResolveAlias", person.AliasName).
+		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_something", nil)
 
 	client.
-		On("ResolveAlias", firm.AliasName).
+		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_something", nil)
 
 	client.
-		On("Indices", "person_*").
+		On("Indices", mock.Anything, "person_*").
 		Return([]string{"person_xyz", "person_something", "person_abc"}, nil)
 
 	client.
-		On("Indices", "firm_*").
+		On("Indices", mock.Anything, "firm_*").
 		Return([]string{"firm_xyz", "firm_something", "firm_abc"}, nil)
 
 	command := NewCleanupIndices(l, client, map[string][]byte{"firm_something": indexConfig, "person_something": indexConfig})

--- a/internal/cmd/create_indices_test.go
+++ b/internal/cmd/create_indices_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"github.com/stretchr/testify/mock"
 	"testing"
 
 	"github.com/ministryofjustice/opg-search-service/internal/elasticsearch"
@@ -39,10 +40,10 @@ func TestCreateIndicesRun(t *testing.T) {
 		t.Run(tc.scenario, func(t *testing.T) {
 			esClient := new(elasticsearch.MockESClient)
 			esClient.
-				On("CreateIndex", "person_test", indexConfig, tc.force).Times(1).Return(tc.error)
+				On("CreateIndex", mock.Anything, "person_test", indexConfig, tc.force).Times(1).Return(tc.error)
 
 			if tc.error == nil {
-				esClient.On("ResolveAlias", "person").Times(1).Return("", nil)
+				esClient.On("ResolveAlias", mock.Anything, "person").Times(1).Return("", nil)
 			}
 
 			command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
@@ -62,9 +63,9 @@ func TestCreateIndicesRun(t *testing.T) {
 func TestCreateIndicesRunCreateAlias(t *testing.T) {
 	esClient := new(elasticsearch.MockESClient)
 	esClient.
-		On("CreateIndex", "person_test", indexConfig, true).Times(1).Return(nil).
-		On("ResolveAlias", "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
-		On("CreateAlias", "person", "person_test").Times(1).Return(nil)
+		On("CreateIndex", mock.Anything, "person_test", indexConfig, true).Times(1).Return(nil).
+		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
+		On("CreateAlias", mock.Anything, "person", "person_test").Times(1).Return(nil)
 
 	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
 
@@ -80,9 +81,9 @@ func TestCreateIndicesRunCreateAliasFails(t *testing.T) {
 
 	esClient := new(elasticsearch.MockESClient)
 	esClient.
-		On("CreateIndex", "person_test", indexConfig, true).Times(1).Return(nil).
-		On("ResolveAlias", "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
-		On("CreateAlias", "person", "person_test").Times(1).Return(creationErr)
+		On("CreateIndex", mock.Anything, "person_test", indexConfig, true).Times(1).Return(nil).
+		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
+		On("CreateAlias", mock.Anything, "person", "person_test").Times(1).Return(creationErr)
 
 	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
 
@@ -98,8 +99,8 @@ func TestCreateIndicesRunResolveAliasFails(t *testing.T) {
 
 	esClient := new(elasticsearch.MockESClient)
 	esClient.
-		On("CreateIndex", "person_test", indexConfig, true).Times(1).Return(nil).
-		On("ResolveAlias", "person").Times(1).Return("", resolveErr)
+		On("CreateIndex", mock.Anything, "person_test", indexConfig, true).Times(1).Return(nil).
+		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", resolveErr)
 
 	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
 
@@ -131,7 +132,7 @@ func TestCreateIndicesRunErrorInFirst(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.scenario, func(t *testing.T) {
 			esClient := new(elasticsearch.MockESClient)
-			esClient.On("CreateIndex", "person_test", indexConfig, tc.force).Times(1).Return(tc.error)
+			esClient.On("CreateIndex", mock.Anything, "person_test", indexConfig, tc.force).Times(1).Return(tc.error)
 
 			command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
 

--- a/internal/cmd/update_alias.go
+++ b/internal/cmd/update_alias.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"strings"
 
@@ -8,8 +9,8 @@ import (
 )
 
 type UpdateAliasClient interface {
-	ResolveAlias(string) (string, error)
-	UpdateAlias(alias, oldIndex, newIndex string) error
+	ResolveAlias(ctx context.Context, alias string) (string, error)
+	UpdateAlias(ctx context.Context, alias, oldIndex, newIndex string) error
 }
 
 type updateAliasCommand struct {
@@ -31,6 +32,7 @@ func (c *updateAliasCommand) Info() (name, description string) {
 }
 
 func (c *updateAliasCommand) Run(args []string) error {
+	ctx := context.Background()
 	flagset := flag.NewFlagSet("update-alias", flag.ExitOnError)
 
 	explain := flagset.Bool("explain", false, "explain the changes that will be made")
@@ -42,7 +44,7 @@ func (c *updateAliasCommand) Run(args []string) error {
 	for indexName := range c.currentIndices {
 		aliasName := strings.Split(indexName, "_")[0]
 
-		aliasedIndex, err := c.client.ResolveAlias(aliasName)
+		aliasedIndex, err := c.client.ResolveAlias(ctx, aliasName)
 		if err != nil {
 			return err
 		}
@@ -55,7 +57,7 @@ func (c *updateAliasCommand) Run(args []string) error {
 		if *explain {
 			c.logger.Printf("will update alias '%s' to '%s'", aliasName, indexName)
 		} else {
-			if err := c.client.UpdateAlias(aliasName, aliasedIndex, indexName); err != nil {
+			if err := c.client.UpdateAlias(ctx, aliasName, aliasedIndex, indexName); err != nil {
 				return err
 			}
 		}

--- a/internal/cmd/update_alias_test.go
+++ b/internal/cmd/update_alias_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ministryofjustice/opg-search-service/internal/firm"
@@ -14,13 +15,13 @@ type mockUpdateAliasClient struct {
 	mock.Mock
 }
 
-func (m *mockUpdateAliasClient) ResolveAlias(alias string) (string, error) {
-	args := m.Called(alias)
+func (m *mockUpdateAliasClient) ResolveAlias(ctx context.Context, alias string) (string, error) {
+	args := m.Called(ctx, alias)
 	return args.String(0), args.Error(1)
 }
 
-func (m *mockUpdateAliasClient) UpdateAlias(alias, oldIndex, newIndex string) error {
-	args := m.Called(alias, oldIndex, newIndex)
+func (m *mockUpdateAliasClient) UpdateAlias(ctx context.Context, alias, oldIndex, newIndex string) error {
+	args := m.Called(ctx, alias, oldIndex, newIndex)
 	return args.Error(0)
 }
 
@@ -29,11 +30,11 @@ func TestUpdatePersonAlias(t *testing.T) {
 	client := &mockUpdateAliasClient{}
 
 	client.
-		On("ResolveAlias", person.AliasName).
+		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_old", nil)
 
 	client.
-		On("UpdateAlias", person.AliasName, "person_old", "person_expected").
+		On("UpdateAlias", mock.Anything, person.AliasName, "person_old", "person_expected").
 		Return(nil)
 
 	command := NewUpdateAlias(l, client, map[string][]byte{"person_expected": indexConfig})
@@ -45,11 +46,11 @@ func TestUpdateFirmAlias(t *testing.T) {
 	client := &mockUpdateAliasClient{}
 
 	client.
-		On("ResolveAlias", firm.AliasName).
+		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_old", nil)
 
 	client.
-		On("UpdateAlias", firm.AliasName, "firm_old", "firm_expected").
+		On("UpdateAlias", mock.Anything, firm.AliasName, "firm_old", "firm_expected").
 		Return(nil)
 
 	command := NewUpdateAlias(l, client, map[string][]byte{"firm_expected": indexConfig})
@@ -61,7 +62,7 @@ func TestUpdatePersonAliasWhenAliasIsCurrent(t *testing.T) {
 	client := &mockUpdateAliasClient{}
 
 	client.
-		On("ResolveAlias", person.AliasName).
+		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_expected", nil)
 
 	command := NewUpdateAlias(l, client, map[string][]byte{"person_expected": indexConfig})
@@ -75,7 +76,7 @@ func TestUpdateFirmAliasWhenAliasIsCurrent(t *testing.T) {
 	client := &mockUpdateAliasClient{}
 
 	client.
-		On("ResolveAlias", firm.AliasName).
+		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_expected", nil)
 
 	command := NewUpdateAlias(l, client, map[string][]byte{"firm_expected": indexConfig})

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -2,6 +2,7 @@ package elasticsearch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,8 +86,8 @@ func NewClient(httpClient HTTPClient, logger *logrus.Logger) (*Client, error) {
 	return client, nil
 }
 
-func (c *Client) doRequest(method, endpoint string, body io.ReadSeeker, contentType string) (*http.Response, error) {
-	req, err := http.NewRequest(method, c.domain+"/"+endpoint, body)
+func (c *Client) doRequest(ctx context.Context, method, endpoint string, body io.ReadSeeker, contentType string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.domain+"/"+endpoint, body)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +168,11 @@ type BulkResult struct {
 	Error      string
 }
 
-func (c *Client) DoBulk(op *BulkOp) (BulkResult, error) {
+func (c *Client) DoBulk(ctx context.Context, op *BulkOp) (BulkResult, error) {
 	retries := 0
 
 	for {
-		res, err := c.doBulkOp(op)
+		res, err := c.doBulkOp(ctx, op)
 		if err == errTooManyRequests && retries < maxRetries {
 			retries++
 			time.Sleep(time.Duration(retries) * backoff)
@@ -182,11 +183,11 @@ func (c *Client) DoBulk(op *BulkOp) (BulkResult, error) {
 	}
 }
 
-func (c *Client) doBulkOp(op *BulkOp) (BulkResult, error) {
+func (c *Client) doBulkOp(ctx context.Context, op *BulkOp) (BulkResult, error) {
 	body := bytes.NewReader(op.buf.Bytes())
 
 	endpoint := fmt.Sprintf("%s/_bulk", op.index)
-	resp, err := c.doRequest(http.MethodPost, endpoint, body, "application/json")
+	resp, err := c.doRequest(ctx, http.MethodPost, endpoint, body, "application/json")
 	if err != nil {
 		c.logger.Error(err.Error())
 
@@ -226,7 +227,7 @@ func (c *Client) doBulkOp(op *BulkOp) (BulkResult, error) {
 }
 
 // returns an array of JSON encoded results
-func (c *Client) Search(indices []string, requestBody map[string]interface{}) (*SearchResult, error) {
+func (c *Client) Search(ctx context.Context, indices []string, requestBody map[string]interface{}) (*SearchResult, error) {
 	endpoint := strings.Join(indices, ",") + "/_search"
 
 	var buf bytes.Buffer
@@ -235,7 +236,7 @@ func (c *Client) Search(indices []string, requestBody map[string]interface{}) (*
 	}
 	body := bytes.NewReader(buf.Bytes())
 
-	resp, err := c.doRequest(http.MethodPost, endpoint, body, "application/json")
+	resp, err := c.doRequest(ctx, http.MethodPost, endpoint, body, "application/json")
 	if err != nil {
 		return nil, err
 	}
@@ -276,8 +277,8 @@ func (c *Client) Search(indices []string, requestBody map[string]interface{}) (*
 	}, nil
 }
 
-func (c *Client) CreateIndex(name string, config []byte, force bool) error {
-	exists, err := c.IndexExists(name)
+func (c *Client) CreateIndex(ctx context.Context, name string, config []byte, force bool) error {
+	exists, err := c.IndexExists(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -290,14 +291,14 @@ func (c *Client) CreateIndex(name string, config []byte, force bool) error {
 
 		c.logger.Printf("changes are forced, deleting old index '%s'", name)
 
-		if err := c.DeleteIndex(name); err != nil {
+		if err := c.DeleteIndex(ctx, name); err != nil {
 			return err
 		}
 
 		c.logger.Printf("index '%s' deleted", name)
 	}
 
-	if err := c.createIndex(name, config); err != nil {
+	if err := c.createIndex(ctx, name, config); err != nil {
 		return err
 	}
 
@@ -305,10 +306,10 @@ func (c *Client) CreateIndex(name string, config []byte, force bool) error {
 	return nil
 }
 
-func (c *Client) IndexExists(name string) (bool, error) {
+func (c *Client) IndexExists(ctx context.Context, name string) (bool, error) {
 	c.logger.Printf("Checking index '%s' exists", name)
 
-	resp, err := c.doRequest(http.MethodHead, name, nil, "")
+	resp, err := c.doRequest(ctx, http.MethodHead, name, nil, "")
 	if err != nil {
 		return false, err
 	}
@@ -324,10 +325,10 @@ func (c *Client) IndexExists(name string) (bool, error) {
 	return false, fmt.Errorf("index check failed with status code %d", resp.StatusCode)
 }
 
-func (c *Client) createIndex(name string, config []byte) error {
+func (c *Client) createIndex(ctx context.Context, name string, config []byte) error {
 	c.logger.Printf("Creating index '%s'", name)
 
-	resp, err := c.doRequest(http.MethodPut, name, bytes.NewReader(config), "application/json")
+	resp, err := c.doRequest(ctx, http.MethodPut, name, bytes.NewReader(config), "application/json")
 	if err != nil {
 		return err
 	}
@@ -341,10 +342,10 @@ func (c *Client) createIndex(name string, config []byte) error {
 	return nil
 }
 
-func (c *Client) DeleteIndex(name string) error {
+func (c *Client) DeleteIndex(ctx context.Context, name string) error {
 	c.logger.Printf("Deleting index '%s'", name)
 
-	resp, err := c.doRequest(http.MethodDelete, name, nil, "application/json")
+	resp, err := c.doRequest(ctx, http.MethodDelete, name, nil, "application/json")
 	if err != nil {
 		return err
 	}
@@ -353,8 +354,8 @@ func (c *Client) DeleteIndex(name string) error {
 	return nil
 }
 
-func (c *Client) ResolveAlias(name string) (string, error) {
-	resp, err := c.doRequest(http.MethodGet, "/_alias/"+name, nil, "")
+func (c *Client) ResolveAlias(ctx context.Context, name string) (string, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, "/_alias/"+name, nil, "")
 	if err != nil {
 		return "", err
 	}
@@ -376,8 +377,8 @@ func (c *Client) ResolveAlias(name string) (string, error) {
 	return "", ErrAliasMissing
 }
 
-func (c *Client) CreateAlias(alias, index string) error {
-	resp, err := c.doRequest(http.MethodPut, fmt.Sprintf("%s/_alias/%s", index, alias), nil, "")
+func (c *Client) CreateAlias(ctx context.Context, alias, index string) error {
+	resp, err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf("%s/_alias/%s", index, alias), nil, "")
 	if err != nil {
 		return err
 	}
@@ -407,7 +408,7 @@ type aliasRequestAction struct {
 	Alias string `json:"alias"`
 }
 
-func (c *Client) UpdateAlias(alias, oldIndex, newIndex string) error {
+func (c *Client) UpdateAlias(ctx context.Context, alias, oldIndex, newIndex string) error {
 	c.logger.Printf("Updating alias '%s' from index '%s' to '%s'", alias, oldIndex, newIndex)
 
 	request, err := json.Marshal(aliasRequest{
@@ -426,7 +427,7 @@ func (c *Client) UpdateAlias(alias, oldIndex, newIndex string) error {
 		return err
 	}
 
-	resp, err := c.doRequest(http.MethodPost, "_aliases", bytes.NewReader(request), "application/json")
+	resp, err := c.doRequest(ctx, http.MethodPost, "_aliases", bytes.NewReader(request), "application/json")
 	if err != nil {
 		return err
 	}
@@ -446,8 +447,8 @@ func (c *Client) UpdateAlias(alias, oldIndex, newIndex string) error {
 	return nil
 }
 
-func (c *Client) Indices(term string) ([]string, error) {
-	resp, err := c.doRequest(http.MethodGet, term, nil, "")
+func (c *Client) Indices(ctx context.Context, term string) ([]string, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, term, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +467,7 @@ func (c *Client) Indices(term string) ([]string, error) {
 	return ks, nil
 }
 
-func (c *Client) Delete(indices []string, requestBody map[string]interface{}) (*DeleteResult, error) {
+func (c *Client) Delete(ctx context.Context, indices []string, requestBody map[string]interface{}) (*DeleteResult, error) {
 	endpoint := strings.Join(indices, ",") + "/_delete_by_query?conflicts=proceed"
 
 	var buf bytes.Buffer
@@ -475,7 +476,7 @@ func (c *Client) Delete(indices []string, requestBody map[string]interface{}) (*
 	}
 	body := bytes.NewReader(buf.Bytes())
 
-	resp, err := c.doRequest(http.MethodPost, endpoint, body, "application/json")
+	resp, err := c.doRequest(ctx, http.MethodPost, endpoint, body, "application/json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/elasticsearch/client_mock.go
+++ b/internal/elasticsearch/client_mock.go
@@ -1,37 +1,40 @@
 package elasticsearch
 
-import "github.com/stretchr/testify/mock"
+import (
+	"context"
+	"github.com/stretchr/testify/mock"
+)
 
 type MockESClient struct {
 	mock.Mock
 }
 
-func (m *MockESClient) DoBulk(op *BulkOp) (BulkResult, error) {
-	args := m.Called(op)
+func (m *MockESClient) DoBulk(ctx context.Context, op *BulkOp) (BulkResult, error) {
+	args := m.Called(ctx, op)
 	return args.Get(0).(BulkResult), args.Error(1)
 }
 
-func (m *MockESClient) Search(indexName []string, requestBody map[string]interface{}) (*SearchResult, error) {
-	args := m.Called(indexName, requestBody)
+func (m *MockESClient) Search(ctx context.Context, indexName []string, requestBody map[string]interface{}) (*SearchResult, error) {
+	args := m.Called(ctx, indexName, requestBody)
 	return args.Get(0).(*SearchResult), args.Error(1)
 }
 
-func (m *MockESClient) Delete(indexName []string, requestBody map[string]interface{}) (*DeleteResult, error) {
-	args := m.Called(indexName, requestBody)
+func (m *MockESClient) Delete(ctx context.Context, indexName []string, requestBody map[string]interface{}) (*DeleteResult, error) {
+	args := m.Called(ctx, indexName, requestBody)
 	return args.Get(0).(*DeleteResult), args.Error(1)
 }
 
-func (m *MockESClient) CreateIndex(name string, config []byte, force bool) error {
-	args := m.Called(name, config, force)
+func (m *MockESClient) CreateIndex(ctx context.Context, name string, config []byte, force bool) error {
+	args := m.Called(ctx, name, config, force)
 	return args.Error(0)
 }
 
-func (m *MockESClient) ResolveAlias(alias string) (string, error) {
-	args := m.Called(alias)
+func (m *MockESClient) ResolveAlias(ctx context.Context, alias string) (string, error) {
+	args := m.Called(ctx, alias)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockESClient) CreateAlias(alias string, index string) error {
-	args := m.Called(alias, index)
+func (m *MockESClient) CreateAlias(ctx context.Context, alias string, index string) error {
+	args := m.Called(ctx, alias, index)
 	return args.Error(0)
 }

--- a/internal/elasticsearch/client_test.go
+++ b/internal/elasticsearch/client_test.go
@@ -2,6 +2,7 @@ package elasticsearch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -100,7 +101,7 @@ func TestClient_DoBulkIndex(t *testing.T) {
 			op := NewBulkOp("this")
 			op.Index(1, map[string]string{"a": "b"})
 
-			result, err := c.DoBulk(op)
+			result, err := c.DoBulk(context.Background(), op)
 
 			if err != nil {
 				assert.Equal(test.expectedError, err.Error())
@@ -169,7 +170,7 @@ func TestClient_DoBulkIndexWithRetry(t *testing.T) {
 	op := NewBulkOp("this")
 	op.Index(1, map[string]string{"a": "b"})
 
-	result, err := c.DoBulk(op)
+	result, err := c.DoBulk(context.Background(), op)
 
 	assert.Nil(err)
 	assert.Equal(BulkResult{Successful: 1}, result)
@@ -203,7 +204,7 @@ func TestClientCreateIndex(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader("test message"))}, nil).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, false)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, false)
 	assert.Nil(err)
 	assert.Contains(hook.LastEntry().Message, "index 'test-index' created")
 }
@@ -225,7 +226,7 @@ func TestClientCreateIndexWhenIndexExists(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, false)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, false)
 	assert.Nil(err)
 	assert.Contains(hook.LastEntry().Message, "index 'test-index' already exists")
 }
@@ -266,7 +267,7 @@ func TestClientCreateIndexWhenIndexExistsAndForced(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader("test message"))}, nil).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, true)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, true)
 	assert.Nil(err)
 	assert.Contains(hook.LastEntry().Message, "index 'test-index' created")
 }
@@ -288,7 +289,7 @@ func TestClientCreateIndexErrorIndexExists(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusInternalServerError, Body: ioutil.NopCloser(strings.NewReader(""))}, nil).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, false)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, false)
 	assert.NotNil(err)
 	assert.Contains(hook.LastEntry().Message, "Checking index 'test-index' exists")
 }
@@ -318,7 +319,7 @@ func TestClientCreateIndexErrorDeleteIndex(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(strings.NewReader(""))}, errors.New("hey")).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, true)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, true)
 	assert.NotNil(err)
 	assert.Contains(hook.LastEntry().Message, "Deleting index 'test-index'")
 }
@@ -351,7 +352,7 @@ func TestClientCreateIndexErrorCreateIndex(t *testing.T) {
 		Return(&http.Response{StatusCode: http.StatusOK}, errors.New("hey")).
 		Once()
 
-	err = client.CreateIndex("test-index", indexConfig, false)
+	err = client.CreateIndex(context.Background(), "test-index", indexConfig, false)
 	assert.NotNil(err)
 	assert.Contains(hook.LastEntry().Message, "Creating index 'test-index'")
 }
@@ -453,7 +454,7 @@ func TestClient_Search(t *testing.T) {
 				test.esResponseError,
 			)
 
-			result, err := c.Search([]string{"test-index"}, reqBody)
+			result, err := c.Search(context.Background(), []string{"test-index"}, reqBody)
 
 			assert.Equal(test.expectedResult, result)
 			if test.expectedError == nil {
@@ -475,7 +476,7 @@ func TestClient_Search_MalformedEndpoint(t *testing.T) {
 
 	c, _ := NewClient(mc, l)
 
-	res, err := c.Search([]string{"test-index"}, map[string]interface{}{})
+	res, err := c.Search(context.Background(), []string{"test-index"}, map[string]interface{}{})
 
 	assert.Nil(t, res)
 	assert.NotNil(t, err)
@@ -494,7 +495,7 @@ func TestClient_Search_InvalidESRequestBody(t *testing.T) {
 	esReqBody := map[string]interface{}{
 		"term": func() {},
 	}
-	res, err := c.Search([]string{"test-index"}, esReqBody)
+	res, err := c.Search(context.Background(), []string{"test-index"}, esReqBody)
 
 	assert.Nil(t, res)
 	assert.NotNil(t, err)
@@ -594,7 +595,7 @@ func TestDelete(t *testing.T) {
 				test.esResponseError,
 			)
 
-			result, err := client.Delete([]string{"test-index"}, reqBody)
+			result, err := client.Delete(context.Background(), []string{"test-index"}, reqBody)
 
 			assert.Equal(test.expectedResult, result)
 

--- a/internal/index/handler_test.go
+++ b/internal/index/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -114,11 +115,11 @@ func (suite *HandlerTestSuite) Test_Index() {
 	secondOp.Index(14, mockIndexable{id: 14})
 
 	suite.esClient.
-		On("DoBulk", firstOp).
+		On("DoBulk", mock.Anything, firstOp).
 		Return(elasticsearch.BulkResult{Successful: 2, Failed: 1}, errors.New("hmm")).
 		Once()
 	suite.esClient.
-		On("DoBulk", secondOp).
+		On("DoBulk", mock.Anything, secondOp).
 		Return(elasticsearch.BulkResult{Successful: 2, Failed: 1}, errors.New("hey")).
 		Once()
 

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -15,7 +15,7 @@ type DB interface {
 }
 
 type BulkClient interface {
-	DoBulk(*elasticsearch.BulkOp) (elasticsearch.BulkResult, error)
+	DoBulk(ctx context.Context, op *elasticsearch.BulkOp) (elasticsearch.BulkResult, error)
 }
 
 type Logger interface {
@@ -100,7 +100,7 @@ func (r *Indexer) index(ctx context.Context, entity <-chan Indexable) (*Result, 
 		err := op.Index(e.Id(), e)
 
 		if err == elasticsearch.ErrOpTooLarge {
-			res, bulkErr := r.es.DoBulk(op)
+			res, bulkErr := r.es.DoBulk(ctx, op)
 			if bulkErr == nil {
 				r.log.Printf("batch indexed successful=%d failed=%d error=%s", res.Successful, res.Failed, res.Error)
 			} else {
@@ -118,7 +118,7 @@ func (r *Indexer) index(ctx context.Context, entity <-chan Indexable) (*Result, 
 	}
 
 	if !op.Empty() {
-		result.Add(r.es.DoBulk(op))
+		result.Add(r.es.DoBulk(ctx, op))
 	}
 
 	return result, nil

--- a/internal/index/indexer_test.go
+++ b/internal/index/indexer_test.go
@@ -37,8 +37,8 @@ type mockClient struct {
 	mock.Mock
 }
 
-func (m *mockClient) DoBulk(op *elasticsearch.BulkOp) (elasticsearch.BulkResult, error) {
-	args := m.Called(op)
+func (m *mockClient) DoBulk(ctx context.Context, op *elasticsearch.BulkOp) (elasticsearch.BulkResult, error) {
+	args := m.Called(ctx, op)
 	return args.Get(0).(elasticsearch.BulkResult), args.Error(1)
 }
 
@@ -68,7 +68,7 @@ func TestAll(t *testing.T) {
 
 	client := &mockClient{}
 	client.
-		On("DoBulk", bulkOp).
+		On("DoBulk", ctx, bulkOp).
 		Return(elasticsearch.BulkResult{Successful: 2, Failed: 0}, nil)
 
 	indexer := New(client, &mockLogger{}, db, "whatever")
@@ -103,7 +103,7 @@ func TestByID(t *testing.T) {
 
 	client := &mockClient{}
 	client.
-		On("DoBulk", bulkOp).
+		On("DoBulk", ctx, bulkOp).
 		Return(elasticsearch.BulkResult{Successful: 2, Failed: 0}, nil)
 
 	indexer := New(client, &mockLogger{}, db, "whatever")
@@ -140,7 +140,7 @@ func TestFromDate(t *testing.T) {
 
 	client := &mockClient{}
 	client.
-		On("DoBulk", bulkOp).
+		On("DoBulk", ctx, bulkOp).
 		Return(elasticsearch.BulkResult{Successful: 2, Failed: 0}, nil)
 
 	indexer := New(client, &mockLogger{}, db, "whatever")

--- a/internal/remove/handler.go
+++ b/internal/remove/handler.go
@@ -1,6 +1,7 @@
 package remove
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 )
 
 type DeleteClient interface {
-	Delete(indices []string, requestBody map[string]interface{}) (*elasticsearch.DeleteResult, error)
+	Delete(ctx context.Context, indices []string, requestBody map[string]interface{}) (*elasticsearch.DeleteResult, error)
 }
 
 type Handler struct {
@@ -46,10 +47,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"uId": uid,
 			},
 		},
-		"max_docs":  1,
+		"max_docs": 1,
 	}
 
-	result, err := h.client.Delete(h.indices, requestBody)
+	result, err := h.client.Delete(r.Context(), h.indices, requestBody)
 	if err != nil {
 		h.logger.Println(err.Error())
 		response.WriteJSONErrors(w, "unexpected error from elasticsearch", []response.Error{}, http.StatusInternalServerError)

--- a/internal/remove/handler_test.go
+++ b/internal/remove/handler_test.go
@@ -77,7 +77,7 @@ func (suite *DeleteHandlerTestSuite) Test_MissingUid() {
 }
 
 func (suite *DeleteHandlerTestSuite) Test_ESReturnsUnexpectedError() {
-	esCall := suite.esClient.On("Delete", mock.Anything, mock.Anything)
+	esCall := suite.esClient.On("Delete", mock.Anything, mock.Anything, mock.Anything)
 	esCall.Return(&elasticsearch.DeleteResult{}, errors.New("test ES error"))
 
 	suite.ServeRequest(http.MethodDelete, "/persons/7000-9000-9201", map[string]string{"uid": "7000-9000-9201"})
@@ -88,7 +88,7 @@ func (suite *DeleteHandlerTestSuite) Test_ESReturnsUnexpectedError() {
 
 func (suite *DeleteHandlerTestSuite) Test_ESReturnsNoResults() {
 	suite.esClient.
-		On("Delete", []string{"whatever"}, mock.Anything).
+		On("Delete", mock.Anything, []string{"whatever"}, mock.Anything).
 		Return(&elasticsearch.DeleteResult{Total: 0}, nil)
 
 	suite.ServeRequest(http.MethodDelete, "/persons/7000-9000-9201", map[string]string{"uid": "7000-9000-9201"})
@@ -99,7 +99,7 @@ func (suite *DeleteHandlerTestSuite) Test_ESReturnsNoResults() {
 
 func (suite *DeleteHandlerTestSuite) Test_ESReturnsMultipleResults() {
 	suite.esClient.
-		On("Delete", []string{"whatever"}, mock.Anything).
+		On("Delete", mock.Anything, []string{"whatever"}, mock.Anything).
 		Return(&elasticsearch.DeleteResult{Total: 2}, nil)
 
 	suite.ServeRequest(http.MethodDelete, "/persons/7000-9000-9201", map[string]string{"uid": "7000-9000-9201"})
@@ -115,7 +115,7 @@ func (suite *DeleteHandlerTestSuite) Test_Delete() {
 				"uId": "7000-9000-9201",
 			},
 		},
-		"max_docs":  1,
+		"max_docs": 1,
 	}
 
 	result := &elasticsearch.DeleteResult{
@@ -123,7 +123,7 @@ func (suite *DeleteHandlerTestSuite) Test_Delete() {
 	}
 
 	suite.esClient.
-		On("Delete", []string{"whatever"}, deleteBody).
+		On("Delete", mock.Anything, []string{"whatever"}, deleteBody).
 		Return(result, nil)
 
 	suite.ServeRequest(http.MethodDelete, "/persons/7000-9000-9201", map[string]string{"uid": "7000-9000-9201"})

--- a/internal/search/handler.go
+++ b/internal/search/handler.go
@@ -46,12 +46,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.client.Search(r.Context(), h.indices, h.prepareQuery(req))
 	if err != nil {
-		code := http.StatusInternalServerError
 		if errors.Is(err, context.Canceled) {
-			code = 499
+			response.WriteJSONError(w, "request", "search request was cancelled", 499)
+		} else {
+			response.WriteJSONError(w, "request", "unexpected error from elasticsearch", http.StatusInternalServerError)
 		}
 		h.logger.Println(err.Error())
-		response.WriteJSONError(w, "request", "unexpected error from elasticsearch", code)
+
 		return
 	}
 

--- a/internal/search/handler.go
+++ b/internal/search/handler.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -45,8 +46,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.client.Search(r.Context(), h.indices, h.prepareQuery(req))
 	if err != nil {
+		code := http.StatusInternalServerError
+		if errors.Is(err, context.Canceled) {
+			code = 499
+		}
 		h.logger.Println(err.Error())
-		response.WriteJSONError(w, "request", "unexpected error from elasticsearch", http.StatusInternalServerError)
+		response.WriteJSONError(w, "request", "unexpected error from elasticsearch", code)
 		return
 	}
 

--- a/internal/search/handler.go
+++ b/internal/search/handler.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -11,7 +12,7 @@ import (
 )
 
 type SearchClient interface {
-	Search(indices []string, requestBody map[string]interface{}) (*elasticsearch.SearchResult, error)
+	Search(ctx context.Context, indices []string, requestBody map[string]interface{}) (*elasticsearch.SearchResult, error)
 }
 
 type PrepareQuery func(*Request) map[string]interface{}
@@ -42,7 +43,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.client.Search(h.indices, h.prepareQuery(req))
+	result, err := h.client.Search(r.Context(), h.indices, h.prepareQuery(req))
 	if err != nil {
 		h.logger.Println(err.Error())
 		response.WriteJSONError(w, "request", "unexpected error from elasticsearch", http.StatusInternalServerError)

--- a/internal/search/handler_test.go
+++ b/internal/search/handler_test.go
@@ -110,7 +110,7 @@ func (suite *SearchHandlerTestSuite) Test_ESReturnsUnexpectedError() {
 		On("Fn", mock.Anything).
 		Return(map[string]interface{}{})
 
-	esCall := suite.esClient.On("Search", mock.Anything, mock.Anything)
+	esCall := suite.esClient.On("Search", mock.Anything, mock.Anything, mock.Anything)
 	esCall.Return(&elasticsearch.SearchResult{}, errors.New("test ES error"))
 
 	suite.ServeRequest(http.MethodPost, "", reqBody)
@@ -142,7 +142,7 @@ func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 	}
 
 	suite.esClient.
-		On("Search", []string{"whatever"}, searchBody).
+		On("Search", mock.Anything, []string{"whatever"}, searchBody).
 		Return(result, nil)
 
 	suite.ServeRequest(http.MethodPost, "", reqBody)

--- a/main.go
+++ b/main.go
@@ -386,13 +386,14 @@ func main() {
 }
 
 func createIndexAndAlias(esClient *elasticsearch.Client, aliasName string, indexName string, indexConfig []byte, l *logrus.Logger) []string {
-	if err := esClient.CreateIndex(indexName, indexConfig, false); err != nil {
+	ctx := context.Background()
+	if err := esClient.CreateIndex(ctx, indexName, indexConfig, false); err != nil {
 		l.Fatal(err)
 	}
 
-	aliasedIndex, err := esClient.ResolveAlias(aliasName)
+	aliasedIndex, err := esClient.ResolveAlias(ctx, aliasName)
 	if err == elasticsearch.ErrAliasMissing {
-		if err := esClient.CreateAlias(aliasName, indexName); err != nil {
+		if err := esClient.CreateAlias(ctx, aliasName, indexName); err != nil {
 			l.Fatal(err)
 		}
 		aliasedIndex = indexName

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -132,12 +133,13 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 
 	indexName, _, _ := person.IndexConfig()
 	indexNameFirm, _, _ := firm.IndexConfig()
+	ctx := context.Background()
 
-	exists, err := suite.esClient.IndexExists(indexName)
+	exists, err := suite.esClient.IndexExists(ctx, indexName)
 	suite.False(exists, "Person index should not exist at this point")
 	suite.Nil(err)
 
-	existsFirmIndex, err := suite.esClient.IndexExists(indexNameFirm)
+	existsFirmIndex, err := suite.esClient.IndexExists(ctx, indexNameFirm)
 	suite.False(existsFirmIndex, "Firm index should not exist at this point")
 	suite.Nil(err)
 
@@ -150,11 +152,11 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 			continue
 		}
 
-		exists, err = suite.esClient.IndexExists(indexName)
+		exists, err = suite.esClient.IndexExists(ctx, indexName)
 		suite.True(exists, "Person index should exist at this point")
 		suite.Nil(err)
 
-		existsFirmIndex, err = suite.esClient.IndexExists(indexNameFirm)
+		existsFirmIndex, err = suite.esClient.IndexExists(ctx, indexNameFirm)
 		suite.True(existsFirmIndex, "Firm index should exist at this point")
 		suite.Nil(err)
 


### PR DESCRIPTION
now using `http.NewRequestWithContext` instead of just `http.NewRequest` so when the parent call is cancelled, any in-flight child requests will also be cancelled, and correctly cascade

Also changed error code to `499` for cancelled search requests