### PR TITLE
Allow indexing when there are no records

### DIFF
--- a/internal/firm/db.go
+++ b/internal/firm/db.go
@@ -19,7 +19,7 @@ type DB struct {
 }
 
 func (db *DB) QueryIDRange(ctx context.Context) (min int, max int, err error) {
-	err = db.conn.QueryRow(ctx, "SELECT MIN(id), MAX(id) FROM firm").Scan(&min, &max)
+	err = db.conn.QueryRow(ctx, "SELECT COALESCE(MIN(id), 0), COALESCE(MAX(id), 0) FROM firm").Scan(&min, &max)
 
 	return min, max, err
 }

--- a/internal/person/db.go
+++ b/internal/person/db.go
@@ -19,7 +19,7 @@ type DB struct {
 }
 
 func (db *DB) QueryIDRange(ctx context.Context) (min int, max int, err error) {
-	err = db.conn.QueryRow(ctx, "SELECT MIN(id), MAX(id) FROM persons").Scan(&min, &max)
+	err = db.conn.QueryRow(ctx, "SELECT COALESCE(MIN(id), 0), COALESCE(MAX(id), 0) FROM persons").Scan(&min, &max)
 
 	return min, max, err
 }


### PR DESCRIPTION
The old query would return `null` for `MIN(id)` and `MAX(id)` if there were no records. This caused a Go error in `.Scan()`, since it's expecting both to be `int`.

This change coalesces null values to 0, so that they are always an int.

Now, if no records exist, it will search for the ID range [0,0], which will return no rows and be quietly skipped over.

Fixes VEGA-1659 #patch