### PR TITLE
SW-4841 Clear secrets cache (experimental)

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -55,3 +55,7 @@ func (c *SecretsCache) GetSecretString(key string) (string, error) {
 func (c *SecretsCache) GetGlobalSecretString(key string) (string, error) {
 	return c.cache.GetSecretString(key)
 }
+
+func (c *SecretsCache) ClearCache() {
+	c.cache, _ = secretcache.New(applyAwsConfig)
+}

--- a/internal/cmd/clear_secret_cache.go
+++ b/internal/cmd/clear_secret_cache.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"errors"
+	"flag"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"os"
+)
+
+type clearSecretCacheCommand struct {
+	logger *logrus.Logger
+	url    string
+}
+
+func NewClearSecretCache(logger *logrus.Logger) *clearSecretCacheCommand {
+	return &clearSecretCacheCommand{
+		logger: logger,
+		url:    "http://localhost:8000" + os.Getenv("PATH_PREFIX") + "/clear-secret-cache",
+	}
+}
+
+func (c *clearSecretCacheCommand) Info() (name, description string) {
+	return "clear-secret-cache", "clear secret cache"
+}
+
+func (c *clearSecretCacheCommand) Run(args []string) error {
+	flagset := flag.NewFlagSet("clear-secret-cache", flag.ExitOnError)
+
+	if err := flagset.Parse(args); err != nil {
+		return err
+	}
+
+	resp, err := http.Get(c.url)
+	if err != nil || resp.StatusCode != 200 {
+		return errors.New("FAIL")
+	}
+	c.logger.Println("Secrets cache cleared")
+	return nil
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -1,0 +1,29 @@
+package secrets
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+type SecretsCache interface {
+	ClearCache()
+}
+
+type Handler struct {
+	logger *logrus.Logger
+	cache  SecretsCache
+}
+
+func NewHandler(logger *logrus.Logger, cache SecretsCache) *Handler {
+	return &Handler{
+		logger: logger,
+		cache:  cache,
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.cache.ClearCache()
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("{}"))
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/ministryofjustice/opg-search-service/internal/secrets"
 	"log"
 	"net/http"
 	"os"
@@ -54,6 +55,7 @@ func main() {
 		cmd.NewIndex(l, esClient, secretsCache, currentIndices),
 		cmd.NewUpdateAlias(l, esClient, currentIndices),
 		cmd.NewCleanupIndices(l, esClient, currentIndices),
+		cmd.NewClearSecretCache(l),
 	)
 
 	personIndices := createIndexAndAlias(esClient, person.AliasName, personIndex, personConfig, l)
@@ -72,6 +74,8 @@ func main() {
 	sm.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+
+	sm.Handle("/clear-secret-cache", secrets.NewHandler(l, secretsCache))
 
 	// Create a sub-router for protected handlers
 	postRouter := sm.Methods(http.MethodPost).Subrouter()


### PR DESCRIPTION
To clear the secrets cache:

docker exec -it opg-sirius-search-service-1 /go/bin/search-service clear-secret-cache