### PR TITLE
VEGA-2000 Include index name in search results #minor

### DIFF
--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -52,7 +52,7 @@ type elasticSearchResponse struct {
 		} `json:"total"`
 		Hits []struct {
 			Index  string          `json:"_index"`
-			Source json.RawMessage `json:"_source"`
+			Source map[string]interface{} `json:"_source"`
 		} `json:"hits"`
 	} `json:"hits"`
 	Aggregations map[string]struct {
@@ -260,16 +260,9 @@ func (c *Client) Search(ctx context.Context, indices []string, requestBody map[s
 
 	hits := make([]json.RawMessage, len(esResponse.Hits.Hits))
 	for i, hit := range esResponse.Hits.Hits {
-		var objs map[string]interface{}
+		hit.Source["_index"] = indexAliasCleaner.ReplaceAllString(hit.Index, "")
 
-		err := json.Unmarshal(hit.Source, &objs)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
-		}
-
-		objs["_index"] = indexAliasCleaner.ReplaceAllString(hit.Index, "")
-
-		result, err := json.Marshal(objs)
+		result, err := json.Marshal(hit.Source)
 		if err != nil {
 			return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
 		}

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -51,7 +51,7 @@ type elasticSearchResponse struct {
 			Relation string `json:"relation"`
 		} `json:"total"`
 		Hits []struct {
-			Index string `json:"_index"`
+			Index  string          `json:"_index"`
 			Source json.RawMessage `json:"_source"`
 		} `json:"hits"`
 	} `json:"hits"`
@@ -262,17 +262,17 @@ func (c *Client) Search(ctx context.Context, indices []string, requestBody map[s
 	for i, hit := range esResponse.Hits.Hits {
 		var objs map[string]interface{}
 
-	    err := json.Unmarshal(hit.Source, &objs)
-	    if err != nil {
-	        return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
-	    }
+		err := json.Unmarshal(hit.Source, &objs)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
+		}
 
-	    objs["_index"] = indexAliasCleaner.ReplaceAllString(hit.Index, "")
+		objs["_index"] = indexAliasCleaner.ReplaceAllString(hit.Index, "")
 
-	    result, err := json.Marshal(objs)
-	    if err != nil {
-	        return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
-	    }
+		result, err := json.Marshal(objs)
+		if err != nil {
+			return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
+		}
 
 		hits[i] = result
 	}

--- a/internal/elasticsearch/client_test.go
+++ b/internal/elasticsearch/client_test.go
@@ -370,12 +370,12 @@ func TestClient_Search(t *testing.T) {
 			scenario:          "Search returns matches",
 			esResponseError:   nil,
 			esResponseCode:    200,
-			esResponseMessage: `{"hits":{"hits":[{"_source":{"id":1,"name":"test1"}},{"_source":{"id":2,"name":"test1"}}]},"aggregations":{"personType":{"buckets":[{"key":"donor","doc_count":2}]}}}`,
+			esResponseMessage: `{"hits":{"hits":[{"_index":"poadraftapplication_foo1111","_source":{"id":1,"name":"test1"}},{"_index":"poadraftapplication_foo1111","_source":{"id":2,"name":"test1"}}]},"aggregations":{"personType":{"buckets":[{"key":"donor","doc_count":2}]}}}`,
 			expectedError:     nil,
 			expectedResult: &SearchResult{
 				Hits: []json.RawMessage{
-					[]byte(`{"id":1,"name":"test1"}`),
-					[]byte(`{"id":2,"name":"test1"}`),
+					[]byte(`{"_index":"poadraftapplication","id":1,"name":"test1"}`),
+					[]byte(`{"_index":"poadraftapplication","id":2,"name":"test1"}`),
 				},
 				Aggregations: map[string]map[string]int{
 					"personType": {

--- a/main_test.go
+++ b/main_test.go
@@ -27,19 +27,19 @@ import (
 func toJSONWithIndex(objs []byte, index string) ([]byte, error) {
 	var tmp map[string]interface{}
 
-    err := json.Unmarshal(objs, &tmp)
-    if err != nil {
-        return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
-    }
+	err := json.Unmarshal(objs, &tmp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
+	}
 
-    tmp["_index"] = index
+	tmp["_index"] = index
 
-    result, err := json.Marshal(tmp)
-    if err != nil {
-        return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
-    }
+	result, err := json.Marshal(tmp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
+	}
 
-    return result, nil
+	return result, nil
 }
 
 func personToJSON(person person.Person) ([]byte, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,35 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// add an _index field to marshalled JSON object objs
+func toJSONWithIndex(objs []byte, index string) ([]byte, error) {
+	var tmp map[string]interface{}
+
+    err := json.Unmarshal(objs, &tmp)
+    if err != nil {
+        return nil, fmt.Errorf("unable to unmarshal JSON for hit: %w", err)
+    }
+
+    tmp["_index"] = index
+
+    result, err := json.Marshal(tmp)
+    if err != nil {
+        return nil, fmt.Errorf("unable to add _index to JSON: %w", err)
+    }
+
+    return result, nil
+}
+
+func personToJSON(person person.Person) ([]byte, error) {
+	objs, _ := json.Marshal(person)
+	return toJSONWithIndex(objs, "person")
+}
+
+func firmToJSON(firm firm.Firm) ([]byte, error) {
+	objs, _ := json.Marshal(firm)
+	return toJSONWithIndex(objs, "firm")
+}
+
 type EndToEndTestSuite struct {
 	suite.Suite
 	testPeople []person.Person
@@ -195,7 +224,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			scenario: "search by surname",
 			term:     suite.testPeople[1].Surname,
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testPeople[1])
+				hit, _ := personToJSON(suite.testPeople[1])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},
@@ -215,7 +244,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			scenario: "search by dob",
 			term:     "01/02/1990",
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testPeople[0])
+				hit, _ := personToJSON(suite.testPeople[0])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},
@@ -235,7 +264,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			scenario: "search by postcode",
 			term:     "NG1 2CD",
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testPeople[0])
+				hit, _ := personToJSON(suite.testPeople[0])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},
@@ -255,7 +284,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			scenario: "search by a-ref",
 			term:     suite.testPeople[1].Cases[0].OnlineLpaId,
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testPeople[1])
+				hit, _ := personToJSON(suite.testPeople[1])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},
@@ -275,7 +304,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchPerson() {
 			scenario: "search by deputy number",
 			term:     strconv.FormatInt(*suite.testPeople[1].DeputyNumber, 10),
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testPeople[1])
+				hit, _ := personToJSON(suite.testPeople[1])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},
@@ -344,7 +373,7 @@ func (suite *EndToEndTestSuite) TestIndexAndSearchFirm() {
 			scenario: "search by firmname",
 			term:     suite.testFirms[1].FirmName,
 			expectedResponse: func() search.Response {
-				hit, _ := json.Marshal(suite.testFirms[1])
+				hit, _ := firmToJSON(suite.testFirms[1])
 
 				return search.Response{
 					Results: []json.RawMessage{hit},


### PR DESCRIPTION
This adds an `_index` field to each search result, which is the name of the ElasticSearch index minus the hash suffix (i.e. `_index` will be "poadraftapplication" rather than "poadraftapplication_a12adsre").

I think this solution is a bit ugly, so if anyone has a more elegant approach, please make suggestions.