### PR TITLE
VEGA-1988 Select indices when calling /searchAll #minor

### DIFF
--- a/internal/search/handler_test.go
+++ b/internal/search/handler_test.go
@@ -22,8 +22,8 @@ type mockPrepareQuery struct {
 	mock.Mock
 }
 
-func (m *mockPrepareQuery) Fn(req *Request) map[string]interface{} {
-	return m.Called(req).Get(0).(map[string]interface{})
+func (m *mockPrepareQuery) Fn(req *Request) ([]string, map[string]interface{}) {
+	return []string{}, m.Called(req).Get(0).(map[string]interface{})
 }
 
 type SearchHandlerTestSuite struct {
@@ -40,7 +40,7 @@ func (suite *SearchHandlerTestSuite) SetupTest() {
 	suite.logger, _ = test.NewNullLogger()
 	suite.esClient = new(elasticsearch.MockESClient)
 	suite.prepareQuery = &mockPrepareQuery{}
-	suite.handler = NewHandler(suite.logger, suite.esClient, []string{"whatever"}, suite.prepareQuery.Fn)
+	suite.handler = NewHandler(suite.logger, suite.esClient, suite.prepareQuery.Fn)
 	suite.recorder = httptest.NewRecorder()
 }
 
@@ -158,7 +158,7 @@ func (suite *SearchHandlerTestSuite) Test_SearchWithAllParameters() {
 	}
 
 	suite.esClient.
-		On("Search", mock.Anything, []string{"whatever"}, searchBody).
+		On("Search", mock.Anything, []string{}, searchBody).
 		Return(result, nil)
 
 	suite.ServeRequest(http.MethodPost, "", reqBody)

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -104,8 +104,13 @@ func PrepareQueryForAll(req *Request) ([]string, map[string]interface{}) {
 		},
 	}
 
-	// TODO get indices from request body
-	return allIndices, withDefaults(req, body)
+	indices := allIndices
+
+	if req.Indices != nil {
+		indices = req.Indices
+	}
+
+	return indices, withDefaults(req, body)
 }
 
 func withDefaults(req *Request, body map[string]interface{}) map[string]interface{} {

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -1,6 +1,17 @@
 package search
 
-func PrepareQueryForDraftApplication(req *Request) map[string]interface{} {
+import (
+	"github.com/ministryofjustice/opg-search-service/internal/firm"
+	"github.com/ministryofjustice/opg-search-service/internal/person"
+	"github.com/ministryofjustice/opg-search-service/internal/poadraftapplication"
+)
+
+var draftApplicationIndices = []string{poadraftapplication.AliasName}
+var firmIndices = []string{firm.AliasName}
+var personIndices = []string{person.AliasName}
+var allIndices = []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}
+
+func PrepareQueryForDraftApplication(req *Request) ([]string, map[string]interface{}) {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
@@ -17,10 +28,10 @@ func PrepareQueryForDraftApplication(req *Request) map[string]interface{} {
 		},
 	}
 
-	return withDefaults(req, body)
+	return draftApplicationIndices, withDefaults(req, body)
 }
 
-func PrepareQueryForFirm(req *Request) map[string]interface{} {
+func PrepareQueryForFirm(req *Request) ([]string, map[string]interface{}) {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
@@ -30,12 +41,12 @@ func PrepareQueryForFirm(req *Request) map[string]interface{} {
 		},
 	}
 
-	return withDefaults(req, body)
+	return firmIndices, withDefaults(req, body)
 }
 
-func PrepareQueryForPerson(req *Request) map[string]interface{} {
+func PrepareQueryForPerson(req *Request) ([]string, map[string]interface{}) {
 	if req.Prepared != nil {
-		return req.Prepared
+		return personIndices, req.Prepared
 	}
 
 	body := map[string]interface{}{
@@ -55,10 +66,10 @@ func PrepareQueryForPerson(req *Request) map[string]interface{} {
 		},
 	}
 
-	return withDefaults(req, body)
+	return personIndices, withDefaults(req, body)
 }
 
-func PrepareQueryForDeputy(req *Request) map[string]interface{} {
+func PrepareQueryForDeputy(req *Request) ([]string, map[string]interface{}) {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
@@ -80,20 +91,21 @@ func PrepareQueryForDeputy(req *Request) map[string]interface{} {
 		},
 	}
 
-	return withDefaults(req, body)
+	return personIndices, withDefaults(req, body)
 }
 
-func PrepareQueryForAll(req *Request) map[string]interface{} {
+func PrepareQueryForAll(req *Request) ([]string, map[string]interface{}) {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
 				"query":  req.Term,
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
 			},
 		},
 	}
 
-	return withDefaults(req, body)
+	// TODO get indices from request body
+	return allIndices, withDefaults(req, body)
 }
 
 func withDefaults(req *Request, body map[string]interface{}) map[string]interface{} {

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -211,36 +211,6 @@ func TestPrepareQueryForPersonAlreadyPrepared(t *testing.T) {
 	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
-func TestPrepareQueryForAll(t *testing.T) {
-	req := &Request{
-		Term: "apples",
-		From: 123,
-	}
-
-	indices, body := PrepareQueryForAll(req)
-
-	assert.Equal(t, map[string]interface{}{
-		"query": map[string]interface{}{
-			"multi_match": map[string]interface{}{
-				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
-			},
-		},
-		"aggs": map[string]interface{}{
-			"personType": map[string]interface{}{
-				"terms": map[string]interface{}{
-					"field": "personType",
-					"size":  "20",
-				},
-			},
-		},
-		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
-	}, body)
-
-	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
-}
-
 func TestPrepareQueryForDeputy(t *testing.T) {
 	req := &Request{
 		Term: "Niko",
@@ -278,12 +248,43 @@ func TestPrepareQueryForDeputy(t *testing.T) {
 	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
+func TestPrepareQueryForAll(t *testing.T) {
+	req := &Request{
+		Term: "apples",
+		From: 123,
+	}
+
+	indices, body := PrepareQueryForAll(req)
+
+	assert.Equal(t, map[string]interface{}{
+		"query": map[string]interface{}{
+			"multi_match": map[string]interface{}{
+				"query":  "apples",
+				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
+			},
+		},
+		"aggs": map[string]interface{}{
+			"personType": map[string]interface{}{
+				"terms": map[string]interface{}{
+					"field": "personType",
+					"size":  "20",
+				},
+			},
+		},
+		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
+		"from":        123,
+	}, body)
+
+	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
+}
+
 func TestPrepareQueryForAllWithOptions(t *testing.T) {
 	req := &Request{
 		Term:        "apples",
 		From:        123,
 		Size:        10,
 		PersonTypes: []string{"deputy", "donor"},
+		Indices:     []string{"firm", "person"},
 	}
 
 	indices, body := PrepareQueryForAll(req)
@@ -311,5 +312,5 @@ func TestPrepareQueryForAllWithOptions(t *testing.T) {
 		"size": 10,
 	}, body)
 
-	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
+	assert.Equal(t, []string{firm.AliasName, person.AliasName}, indices)
 }

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ministryofjustice/opg-search-service/internal/firm"
+	"github.com/ministryofjustice/opg-search-service/internal/person"
+	"github.com/ministryofjustice/opg-search-service/internal/poadraftapplication"
 )
 
 func TestPrepareQueryForDraftApplication(t *testing.T) {
@@ -12,7 +16,7 @@ func TestPrepareQueryForDraftApplication(t *testing.T) {
 		From: 123,
 	}
 
-	body := PrepareQueryForDraftApplication(req)
+	indices, body := PrepareQueryForDraftApplication(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -39,6 +43,8 @@ func TestPrepareQueryForDraftApplication(t *testing.T) {
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
 		"from":        123,
 	}, body)
+
+	assert.Equal(t, []string{poadraftapplication.AliasName}, indices)
 }
 
 func TestPrepareQueryForFirm(t *testing.T) {
@@ -47,7 +53,7 @@ func TestPrepareQueryForFirm(t *testing.T) {
 		From: 123,
 	}
 
-	body := PrepareQueryForFirm(req)
+	indices, body := PrepareQueryForFirm(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -67,6 +73,8 @@ func TestPrepareQueryForFirm(t *testing.T) {
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
 		"from":        123,
 	}, body)
+
+	assert.Equal(t, []string{firm.AliasName}, indices)
 }
 
 func TestPrepareQueryForFirmWithOptions(t *testing.T) {
@@ -77,7 +85,7 @@ func TestPrepareQueryForFirmWithOptions(t *testing.T) {
 		PersonTypes: []string{"deputy", "donor"},
 	}
 
-	body := PrepareQueryForFirm(req)
+	indices, body := PrepareQueryForFirm(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -101,6 +109,8 @@ func TestPrepareQueryForFirmWithOptions(t *testing.T) {
 		"from": 123,
 		"size": 10,
 	}, body)
+
+	assert.Equal(t, []string{firm.AliasName}, indices)
 }
 
 func TestPrepareQueryForPerson(t *testing.T) {
@@ -109,7 +119,7 @@ func TestPrepareQueryForPerson(t *testing.T) {
 		From: 123,
 	}
 
-	body := PrepareQueryForPerson(req)
+	indices, body := PrepareQueryForPerson(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -137,6 +147,8 @@ func TestPrepareQueryForPerson(t *testing.T) {
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
 		"from":        123,
 	}, body)
+
+	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
 func TestPrepareQueryForPersonWithOptions(t *testing.T) {
@@ -147,7 +159,7 @@ func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 		PersonTypes: []string{"deputy", "donor"},
 	}
 
-	body := PrepareQueryForPerson(req)
+	indices, body := PrepareQueryForPerson(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -179,6 +191,8 @@ func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 		"from": 123,
 		"size": 10,
 	}, body)
+
+	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
 func TestPrepareQueryForPersonAlreadyPrepared(t *testing.T) {
@@ -188,11 +202,13 @@ func TestPrepareQueryForPersonAlreadyPrepared(t *testing.T) {
 		},
 	}
 
-	body := PrepareQueryForPerson(req)
+	indices, body := PrepareQueryForPerson(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": "some prepared query",
 	}, body)
+
+	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
 func TestPrepareQueryForAll(t *testing.T) {
@@ -201,13 +217,13 @@ func TestPrepareQueryForAll(t *testing.T) {
 		From: 123,
 	}
 
-	body := PrepareQueryForAll(req)
+	indices, body := PrepareQueryForAll(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -221,6 +237,8 @@ func TestPrepareQueryForAll(t *testing.T) {
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
 		"from":        123,
 	}, body)
+
+	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
 }
 
 func TestPrepareQueryForDeputy(t *testing.T) {
@@ -229,7 +247,7 @@ func TestPrepareQueryForDeputy(t *testing.T) {
 		From: 9,
 	}
 
-	body := PrepareQueryForDeputy(req)
+	indices, body := PrepareQueryForDeputy(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
@@ -256,6 +274,8 @@ func TestPrepareQueryForDeputy(t *testing.T) {
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
 		"from":        9,
 	}, body)
+
+	assert.Equal(t, []string{person.AliasName}, indices)
 }
 
 func TestPrepareQueryForAllWithOptions(t *testing.T) {
@@ -266,13 +286,13 @@ func TestPrepareQueryForAllWithOptions(t *testing.T) {
 		PersonTypes: []string{"deputy", "donor"},
 	}
 
-	body := PrepareQueryForAll(req)
+	indices, body := PrepareQueryForAll(req)
 
 	assert.Equal(t, map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
 				"query":  "apples",
-				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable", "searchable"},
+				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
 			},
 		},
 		"aggs": map[string]interface{}{
@@ -290,4 +310,6 @@ func TestPrepareQueryForAllWithOptions(t *testing.T) {
 		"from": 123,
 		"size": 10,
 	}, body)
+
+	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
 }

--- a/internal/search/search_request.go
+++ b/internal/search/search_request.go
@@ -16,6 +16,7 @@ type Request struct {
 	From        int                    `json:"from"`
 	PersonTypes []string               `json:"person_types"`
 	Prepared    map[string]interface{} `json:"prepared"`
+	Indices    []string                `json:"indices"`
 }
 
 func parseSearchRequest(r *http.Request) (*Request, error) {

--- a/internal/search/search_request_test.go
+++ b/internal/search/search_request_test.go
@@ -63,6 +63,15 @@ func TestCreateSearchRequestFromRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			"created request can include indices to use for search",
+			`{"term":"Vega","indices":["person","firm"]}`,
+			nil,
+			&Request{
+				Term: "Vega",
+				Indices: []string{"person", "firm"},
+			},
+		},
 	}
 	for _, test := range tests {
 		req := http.Request{

--- a/main.go
+++ b/main.go
@@ -321,17 +321,17 @@ func main() {
 	//   '500':
 	//     description: Unexpected error occurred
 	postRouter.Handle("/persons", index.NewHandler(l, esClient, personIndices, person.ParseIndexRequest))
-	postRouter.Handle("/persons/search", search.NewHandler(l, esClient, []string{person.AliasName}, search.PrepareQueryForPerson))
+	postRouter.Handle("/persons/search", search.NewHandler(l, esClient, search.PrepareQueryForPerson))
 
-	postRouter.Handle("/deputies/search", search.NewHandler(l, esClient, []string{person.AliasName}, search.PrepareQueryForDeputy))
+	postRouter.Handle("/deputies/search", search.NewHandler(l, esClient, search.PrepareQueryForDeputy))
 
 	postRouter.Handle("/firms", index.NewHandler(l, esClient, firmIndices, firm.ParseIndexRequest))
-	postRouter.Handle("/firms/search", search.NewHandler(l, esClient, []string{firm.AliasName}, search.PrepareQueryForFirm))
+	postRouter.Handle("/firms/search", search.NewHandler(l, esClient, search.PrepareQueryForFirm))
 
 	postRouter.Handle("/draftApplications", index.NewHandler(l, esClient, poaDraftApplicationIndices, poadraftapplication.ParseIndexRequest))
-	postRouter.Handle("/draftApplications/search", search.NewHandler(l, esClient, []string{poadraftapplication.AliasName}, search.PrepareQueryForDraftApplication))
+	postRouter.Handle("/draftApplications/search", search.NewHandler(l, esClient, search.PrepareQueryForDraftApplication))
 
-	postRouter.Handle("/searchAll", search.NewHandler(l, esClient, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, search.PrepareQueryForAll))
+	postRouter.Handle("/searchAll", search.NewHandler(l, esClient, search.PrepareQueryForAll))
 
 	deleteRouter := sm.Methods(http.MethodDelete).Subrouter()
 	deleteRouter.Use(middleware.JwtVerify(secretsCache, l))


### PR DESCRIPTION
This defaults to all indices. Use an "indices" property in the search request to limit to particular indices. Choices are "person", "firm", "poadraftapplication"; pass as an array in the JSON POST body to the /searchAll endpoint.