### PR TITLE
VEGA-2020 separate draft application donor name fields

### DIFF
--- a/internal/poadraftapplication/db.go
+++ b/internal/poadraftapplication/db.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/jackc/pgx/v4"
 	"github.com/ministryofjustice/opg-search-service/internal/index"
 )
 
@@ -14,11 +13,12 @@ type DB struct {
 }
 
 type rowResult struct {
-	ID int
-	UID string
-	donorname string
-	donorpostcode string
-	donordob string
+	ID              int
+	UID             string
+	donorfirstnames string
+	donorlastname   string
+	donorpostcode   string
+	donordob        string
 }
 
 func NewDB(conn *pgx.Conn) *DB {
@@ -30,7 +30,7 @@ func (db *DB) QueryIDRange(ctx context.Context) (min int, max int, err error) {
 }
 
 func (db *DB) QueryByID(ctx context.Context, results chan<- index.Indexable, from, to int) error {
-	query := `SELECT COALESCE(c.caserecnumber, ''), COALESCE(a.donorname, ''), coalesce(to_char(a.donordob, 'DD/MM/YYYY'), ''), COALESCE(a.donorpostcode, '')
+	query := `SELECT COALESCE(c.caserecnumber, ''), COALESCE(a.donorfirstnames, ''), COALESCE(a.donorlastname, ''), coalesce(to_char(a.donordob, 'DD/MM/YYYY'), ''), COALESCE(a.donorpostcode, '')
 FROM poa.draft_applications a
 INNER JOIN cases c ON c.id = a.lpa_id
 WHERE a.id >= $1 AND a.id <= $2
@@ -43,7 +43,7 @@ ORDER BY a.id`
 
 	for rows.Next() {
 		var r rowResult
-		err = rows.Scan(&r.UID, &r.donorname, &r.donordob, &r.donorpostcode)
+		err = rows.Scan(&r.UID, &r.donorfirstnames, &r.donorlastname, &r.donordob, &r.donorpostcode)
 
 		if err != nil {
 			break
@@ -52,9 +52,10 @@ ORDER BY a.id`
 		d := DraftApplication{
 			UID: r.UID,
 			Donor: DraftApplicationDonor{
-				Name: r.donorname,
-				Dob: r.donordob,
-				Postcode: r.donorpostcode,
+				FirstNames: r.donorfirstnames,
+				LastName:   r.donorlastname,
+				Dob:        r.donordob,
+				Postcode:   r.donorpostcode,
 			},
 		}
 

--- a/internal/poadraftapplication/db.go
+++ b/internal/poadraftapplication/db.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/ministryofjustice/opg-search-service/internal/index"
 )
 

--- a/internal/poadraftapplication/db_test.go
+++ b/internal/poadraftapplication/db_test.go
@@ -49,9 +49,9 @@ func TestGetIDRange(t *testing.T) {
 	assert.Nil(err)
 
 	_, err = conn.Exec(ctx, `
-		INSERT INTO poa.draft_applications (id, lpa_id, donorname, donordob, donorpostcode)
-		VALUES (1, 101, 'TLane Araxa', '12/12/2000', 'X11 11X'),
-		(2, 102, 'MMosa SepIch', '09/09/1999', 'Y11 11Y');
+		INSERT INTO poa.draft_applications (id, lpa_id, donorfirstnames, donorlastname, donordob, donorpostcode)
+		VALUES (1, 101, 'TLane', 'Araxa', '12/12/2000', 'X11 11X'),
+		(2, 102, 'MMosa', 'SepIch', '09/09/1999', 'Y11 11Y');
 	`)
 	assert.Nil(err)
 
@@ -91,12 +91,11 @@ func TestQueryByID(t *testing.T) {
 	assert.Nil(err)
 
 	_, err = conn.Exec(ctx, `
-		INSERT INTO poa.draft_applications (id, lpa_id, donorname, donordob, donorpostcode)
-		VALUES (1, 101, 'TLane Araxa', '12/12/2000', 'X11 11X'),
-		(2, 102, 'MMosa SepIch', '09/09/1999', 'Y11 11Y');
+		INSERT INTO poa.draft_applications (id, lpa_id, donorfirstnames, donorlastname, donordob, donorpostcode)
+		VALUES (1, 101, 'TLane', 'Araxa', '12/12/2000', 'X11 11X'),
+		(2, 102, 'MMosa', 'SepIch', '09/09/1999', 'Y11 11Y');
 	`)
 	assert.Nil(err)
-
 
 	resultsCh := make(chan index.Indexable)
 	db := DB{conn: conn}
@@ -113,9 +112,10 @@ func TestQueryByID(t *testing.T) {
 	assert.Equal(DraftApplication{
 		UID: firstUid,
 		Donor: DraftApplicationDonor{
-			Name: "TLane Araxa",
-			Dob: "12/12/2000",
-			Postcode: "X11 11X",
+			FirstNames: "TLane",
+			LastName:   "Araxa",
+			Dob:        "12/12/2000",
+			Postcode:   "X11 11X",
 		},
 	}, first)
 
@@ -126,9 +126,10 @@ func TestQueryByID(t *testing.T) {
 	assert.Equal(DraftApplication{
 		UID: secondUid,
 		Donor: DraftApplicationDonor{
-			Name: "MMosa SepIch",
-			Dob: "09/09/1999",
-			Postcode: "Y11 11Y",
+			FirstNames: "MMosa",
+			LastName:   "SepIch",
+			Dob:        "09/09/1999",
+			Postcode:   "Y11 11Y",
 		},
 	}, second)
 

--- a/internal/poadraftapplication/index_request_test.go
+++ b/internal/poadraftapplication/index_request_test.go
@@ -12,8 +12,8 @@ func TestIndexRequest_Validate(t *testing.T) {
 	var noErrs []response.Error
 
 	tests := []struct {
-		scenario string
-		request IndexRequest
+		scenario   string
+		request    IndexRequest
 		expectErrs []response.Error
 	}{
 		{
@@ -23,9 +23,10 @@ func TestIndexRequest_Validate(t *testing.T) {
 					{
 						UID: testId,
 						Donor: DraftApplicationDonor{
-							Name: "Vancep BVigliaon",
-							Dob: "12/12/2000",
-							Postcode: "X11 11X",
+							FirstNames: "Vancep",
+							LastName:   "BVigliaon",
+							Dob:        "12/12/2000",
+							Postcode:   "X11 11X",
 						},
 					},
 				},
@@ -37,7 +38,7 @@ func TestIndexRequest_Validate(t *testing.T) {
 			IndexRequest{},
 			[]response.Error{
 				{
-					Name: "draftApplications",
+					Name:        "draftApplications",
 					Description: "field is empty",
 				},
 			},

--- a/internal/poadraftapplication/poa_draft_application.go
+++ b/internal/poadraftapplication/poa_draft_application.go
@@ -11,13 +11,14 @@ import (
 const AliasName = "poadraftapplication"
 
 type DraftApplicationDonor struct {
-	Name string `json:"name"`
-	Dob string `json:"dob"`
-	Postcode string `json:"postcode"`
+	FirstNames string `json:"firstnames"`
+	LastName   string `json:"lastname"`
+	Dob        string `json:"dob"`
+	Postcode   string `json:"postcode"`
 }
 
 type DraftApplication struct {
-	UID string `json:"uId"`
+	UID   string                `json:"uId"`
 	Donor DraftApplicationDonor `json:"donor"`
 }
 
@@ -30,7 +31,7 @@ func (d DraftApplication) Validate() []response.Error {
 
 	if len(d.UID) == 0 {
 		errs = append(errs, response.Error{
-			Name: "uId",
+			Name:        "uId",
 			Description: "field is empty",
 		})
 	}
@@ -44,25 +45,25 @@ func IndexConfig() (name string, config []byte, err error) {
 
 	draftApplicationConfig := map[string]interface{}{
 		"settings": map[string]interface{}{
-			"number_of_shards": 1,
+			"number_of_shards":   1,
 			"number_of_replicas": 1,
-			"refresh_interval": "1s",
+			"refresh_interval":   "1s",
 			"analysis": map[string]interface{}{
 				"filter": map[string]interface{}{
 					"whitespace_remove": map[string]interface{}{
-						"type": "pattern_replace",
-						"pattern": " ",
+						"type":        "pattern_replace",
+						"pattern":     " ",
 						"replacement": "",
 					},
 				},
 				"analyzer": map[string]interface{}{
 					"default": map[string]interface{}{
 						"tokenizer": "whitespace",
-						"filter": []string{"asciifolding", "lowercase"},
+						"filter":    []string{"asciifolding", "lowercase"},
 					},
 					"no_space_analyzer": map[string]interface{}{
 						"tokenizer": "keyword",
-						"filter": []string{"whitespace_remove", "lowercase"},
+						"filter":    []string{"whitespace_remove", "lowercase"},
 					},
 				},
 			},
@@ -70,15 +71,16 @@ func IndexConfig() (name string, config []byte, err error) {
 		"mappings": map[string]interface{}{
 			"properties": map[string]interface{}{
 				"searchable": textField,
-				"uId": searchableTextField,
+				"uId":        searchableTextField,
 				"donor": map[string]interface{}{
 					"properties": map[string]interface{}{
-						"name": searchableTextField,
-						"dob": searchableTextField,
+						"firstnames": searchableTextField,
+						"lastname":   searchableTextField,
+						"dob":        searchableTextField,
 						"postcode": map[string]interface{}{
-							"type": "text",
+							"type":     "text",
 							"analyzer": "no_space_analyzer",
-							"copy_to": "searchable",
+							"copy_to":  "searchable",
 						},
 					},
 				},

--- a/internal/testdata/schema.sql
+++ b/internal/testdata/schema.sql
@@ -321,7 +321,8 @@ CREATE TABLE poa.draft_applications
 (
     id integer NOT NULL,
     lpa_id integer NOT NULL,
-    donorname character varying(255) NOT NULL,
+    donorfirstnames character varying(255) NOT NULL,
+    donorlastname character varying(255) NOT NULL,
     donordob TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
     donorpostcode character varying(255) NOT NULL,
     CONSTRAINT draft_applications_pkey PRIMARY KEY (id)


### PR DESCRIPTION
`donorname` no longer exists in the `poa.draft_applications` table and has been replaced with separate fields for `donorfirstnames` and `donorlastname`. This PR is to reflect those changes here in the search service
VEGA-2020 #patch