### PR TITLE
Add test for request signing

### DIFF
--- a/internal/elasticsearch/client_test.go
+++ b/internal/elasticsearch/client_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -611,4 +612,30 @@ func TestDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientSignRequest(t *testing.T) {
+	assert := assert.New(t)
+
+	AUTH_HEADER_PATTERN := `^AWS4-HMAC-SHA256 Credential=[^ ]+, SignedHeaders=content-type;host;x-amz-date, Signature=[a-f0-9]+$`
+
+	httpClient := &MockHttpClient{}
+	l, _ := logrus_test.NewNullLogger()
+
+	client, err := NewClient(httpClient, l)
+	assert.Nil(err)
+
+	httpClient.
+		On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			matched, _ := regexp.MatchString(AUTH_HEADER_PATTERN, req.Header["Authorization"][0])
+
+			return req.Method == http.MethodGet &&
+				req.URL.String() == os.Getenv("AWS_ELASTICSEARCH_ENDPOINT")+"/_healthcheck" &&
+				matched
+		})).
+		Return(&http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil).
+		Once()
+
+	_, err = client.doRequest(context.Background(), http.MethodGet, "_healthcheck", bytes.NewReader([]byte{}), "application/json")
+	assert.Nil(err)
 }


### PR DESCRIPTION
To ensure the signer endpoint is being claled and is attaching a valid-looking Authorization header

For SP-1308