### PR TITLE
Fix errors identified by linting:

### DIFF
--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -110,7 +110,7 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, body io
 
 	_, err = c.signer.Sign(req, body, c.service, c.region, time.Now())
 	if err != nil {
-		return nil, err 
+		return nil, err
 	}
 
 	return c.httpClient.Do(req)
@@ -359,7 +359,7 @@ func (c *Client) createIndex(ctx context.Context, name string, config []byte) er
 
 	if resp.StatusCode != http.StatusOK {
 		data, _ := io.ReadAll(resp.Body)
-		return errors.New(fmt.Sprintf(`index creation failed with status code %d and response: "%s"`, resp.StatusCode, string(data)))
+		return fmt.Errorf(`index creation failed with status code %d and response: "%s"`, resp.StatusCode, string(data))
 	}
 
 	return nil

--- a/internal/elasticsearch/client_test.go
+++ b/internal/elasticsearch/client_test.go
@@ -99,7 +99,8 @@ func TestClient_DoBulkIndex(t *testing.T) {
 			)
 
 			op := NewBulkOp("this")
-			op.Index("1", map[string]string{"a": "b"})
+			err = op.Index("1", map[string]string{"a": "b"})
+			assert.Nil(err)
 
 			result, err := c.DoBulk(context.Background(), op)
 
@@ -168,7 +169,8 @@ func TestClient_DoBulkIndexWithRetry(t *testing.T) {
 		Once()
 
 	op := NewBulkOp("this")
-	op.Index("1", map[string]string{"a": "b"})
+	err = op.Index("1", map[string]string{"a": "b"})
+	assert.Nil(err)
 
 	result, err := c.DoBulk(context.Background(), op)
 
@@ -504,9 +506,12 @@ func TestClient_Search_InvalidESRequestBody(t *testing.T) {
 
 func TestBulkOp(t *testing.T) {
 	op := NewBulkOp("test")
-	op.Index("1", map[string]interface{}{"a": 1})
-	op.Index("2", map[string]interface{}{"b": "c"})
-	op.Index("3", map[string]interface{}{"d": false})
+	err := op.Index("1", map[string]interface{}{"a": 1})
+	assert.Nil(t, err)
+	err = op.Index("2", map[string]interface{}{"b": "c"})
+	assert.Nil(t, err)
+	err = op.Index("3", map[string]interface{}{"d": false})
+	assert.Nil(t, err)
 
 	expected := `{"index":{"_id":"1"}}
 {"a":1}

--- a/internal/index/handler_test.go
+++ b/internal/index/handler_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/ministryofjustice/opg-search-service/internal/elasticsearch"
 	"github.com/ministryofjustice/opg-search-service/internal/middleware"
 	"github.com/ministryofjustice/opg-search-service/internal/response"
@@ -24,7 +24,6 @@ type HandlerTestSuite struct {
 	logger            *logrus.Logger
 	esClient          *elasticsearch.MockESClient
 	handler           *Handler
-	router            *mux.Router
 	recorder          *httptest.ResponseRecorder
 	respBody          *string
 	parserValidatable Validatable
@@ -108,11 +107,15 @@ func (suite *HandlerTestSuite) Test_Index() {
 	reqBody := `{"whatevers":[{"id":13},{"id":14}]}`
 
 	firstOp := elasticsearch.NewBulkOp("whatever-test")
-	firstOp.Index("13", mockIndexable{id: "13"})
-	firstOp.Index("14", mockIndexable{id: "14"})
+	err := firstOp.Index("13", mockIndexable{id: "13"})
+	suite.Nil(err)
+	err = firstOp.Index("14", mockIndexable{id: "14"})
+	suite.Nil(err)
 	secondOp := elasticsearch.NewBulkOp("whatever-new")
-	secondOp.Index("13", mockIndexable{id: "13"})
-	secondOp.Index("14", mockIndexable{id: "14"})
+	err = secondOp.Index("13", mockIndexable{id: "13"})
+	suite.Nil(err)
+	err = secondOp.Index("14", mockIndexable{id: "14"})
+	suite.Nil(err)
 
 	suite.esClient.
 		On("DoBulk", mock.Anything, firstOp).

--- a/internal/index/indexer_test.go
+++ b/internal/index/indexer_test.go
@@ -63,8 +63,10 @@ func TestAll(t *testing.T) {
 		Return(nil)
 
 	bulkOp := elasticsearch.NewBulkOp("whatever")
-	bulkOp.Index("1", first)
-	bulkOp.Index("2", second)
+	err := bulkOp.Index("1", first)
+	assert.Nil(err)
+	err = bulkOp.Index("2", second)
+	assert.Nil(err)
 
 	client := &mockClient{}
 	client.
@@ -98,8 +100,10 @@ func TestByID(t *testing.T) {
 		Return(nil)
 
 	bulkOp := elasticsearch.NewBulkOp("whatever")
-	bulkOp.Index("1", first)
-	bulkOp.Index("2", second)
+	err := bulkOp.Index("1", first)
+	assert.Nil(err)
+	err = bulkOp.Index("2", second)
+	assert.Nil(err)
 
 	client := &mockClient{}
 	client.
@@ -135,8 +139,10 @@ func TestFromDate(t *testing.T) {
 		Return(nil)
 
 	bulkOp := elasticsearch.NewBulkOp("whatever")
-	bulkOp.Index("1", first)
-	bulkOp.Index("2", second)
+	err := bulkOp.Index("1", first)
+	assert.Nil(err)
+	err = bulkOp.Index("2", second)
+	assert.Nil(err)
 
 	client := &mockClient{}
 	client.

--- a/internal/middleware/jwt_auth.go
+++ b/internal/middleware/jwt_auth.go
@@ -14,11 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type authorisationError struct {
-	Error       string `json:"error"`
-	Description string `json:"error_description"`
-}
-
 type HashedEmail struct{}
 
 type Cacheable interface {

--- a/internal/remove/handler_test.go
+++ b/internal/remove/handler_test.go
@@ -34,10 +34,6 @@ func (suite *DeleteHandlerTestSuite) SetupTest() {
 	suite.recorder = httptest.NewRecorder()
 }
 
-const (
-	varsKey = iota
-)
-
 func (suite *DeleteHandlerTestSuite) ServeRequest(method string, url string, vars map[string]string) {
 	req, err := http.NewRequest(method, url, strings.NewReader(""))
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -436,7 +436,10 @@ func i64(i int) *int64 {
 
 func doRequest(authHeader, path string, data interface{}) (*http.Response, error) {
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(data)
+	err := json.NewEncoder(&buf).Encode(data)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest(http.MethodPost, "http://localhost:8000"+os.Getenv("PATH_PREFIX")+path, &buf)
 	if err != nil {


### PR DESCRIPTION
- Checking the error response of functions in tests
- Handling gradeful shutdown better (signal must be buffered, os.Kill can't be trapped, cancelFn must be handled)
- Use `fmt.Errorf(...)` instead of `errors.New(fmt.Sprintf(...))`
- Remove unused properties, structs and consts

#patch