### PR TITLE
Ensure fallback to "all indices" works

### DIFF
--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -106,7 +106,7 @@ func PrepareQueryForAll(req *Request) ([]string, map[string]interface{}) {
 
 	indices := allIndices
 
-	if req.Indices != nil {
+	if len(req.Indices) > 0 {
 		indices = req.Indices
 	}
 

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -250,8 +250,39 @@ func TestPrepareQueryForDeputy(t *testing.T) {
 
 func TestPrepareQueryForAll(t *testing.T) {
 	req := &Request{
-		Term: "apples",
-		From: 123,
+		Term:    "apples",
+		From:    123,
+	}
+
+	indices, body := PrepareQueryForAll(req)
+
+	assert.Equal(t, map[string]interface{}{
+		"query": map[string]interface{}{
+			"multi_match": map[string]interface{}{
+				"query":  "apples",
+				"fields": []string{"firmName", "firmNumber", "caseRecNumber", "searchable"},
+			},
+		},
+		"aggs": map[string]interface{}{
+			"personType": map[string]interface{}{
+				"terms": map[string]interface{}{
+					"field": "personType",
+					"size":  "20",
+				},
+			},
+		},
+		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
+		"from":        123,
+	}, body)
+
+	assert.Equal(t, []string{firm.AliasName, person.AliasName, poadraftapplication.AliasName}, indices)
+}
+
+func TestPrepareQueryForAllEmptyIndices(t *testing.T) {
+	req := &Request{
+		Term:    "apples",
+		From:    123,
+		Indices: []string{},
 	}
 
 	indices, body := PrepareQueryForAll(req)


### PR DESCRIPTION
In `PrepareQueryForAll` we should fallback to all indices if the slice is empty, even if it is not-nil.

I didn't actually think it was possible for a slice to be nil, but here we are.

Fixes VEGA-2085 #patch