### PR TITLE
VEGA-2096 The firm table is now in the supervision schema #minor

### DIFF
--- a/internal/firm/db.go
+++ b/internal/firm/db.go
@@ -19,7 +19,7 @@ type DB struct {
 }
 
 func (db *DB) QueryIDRange(ctx context.Context) (min int, max int, err error) {
-	err = db.conn.QueryRow(ctx, "SELECT COALESCE(MIN(id), 0), COALESCE(MAX(id), 0) FROM firm").Scan(&min, &max)
+	err = db.conn.QueryRow(ctx, "SELECT COALESCE(MIN(id), 0), COALESCE(MAX(id), 0) FROM supervision.firm").Scan(&min, &max)
 
 	return min, max, err
 }
@@ -42,7 +42,7 @@ func makeQueryFirm(whereClause string) string {
 		coalesce(f.addressline1, ''), coalesce(f.addressline2, ''), coalesce(f.addressline3, ''),
 		coalesce(f.town, ''), coalesce(f.county, ''), coalesce(f.postcode, ''),
 		coalesce(f.phonenumber, '')
-FROM firm f
+FROM supervision.firm f
 WHERE ` + whereClause + `
 ORDER BY f.id`
 }

--- a/internal/firm/db_test.go
+++ b/internal/firm/db_test.go
@@ -45,7 +45,7 @@ func TestGetIDRange(t *testing.T) {
 	}
 
 	_, err = conn.Exec(ctx, `
-		INSERT INTO firm (id, firmname, addressline1, town, county, postcode, phonenumber, email, firmnumber)
+		INSERT INTO supervision.firm (id, firmname, addressline1, town, county, postcode, phonenumber, email, firmnumber)
 		VALUES (1, 'firm co', '123 Fake street', 'Faketon', 'Fakeshire', 'F1 1FF', '0111111111', 'email@example.com', '1234'),
 		(2, 'firm co', '123 Fake street', 'Faketon', 'Fakeshire', 'F1 1FF', '0111111111', 'email@example.com', '1234'),
 		(3, 'firm co', '123 Fake street', 'Faketon', 'Fakeshire', 'F1 1FF', '0111111111', 'email@example.com', '1234');
@@ -85,7 +85,7 @@ func TestQueryByID(t *testing.T) {
 	}
 
 	_, err = conn.Exec(ctx, `
-		INSERT INTO firm (id, firmname, addressline1, town, county, postcode, phonenumber, email, firmnumber)
+		INSERT INTO supervision.firm (id, firmname, addressline1, town, county, postcode, phonenumber, email, firmnumber)
 		VALUES (1, 'firm co', '123 Fake street', 'Faketon', 'Fakeshire', 'F1 1FF', '0111111111', 'email@example.com', 1234),
 		(2, 'firm co', '123 Fake street', 'Faketon', 'Fakeshire', 'F1 1FF', '0111111111', 'email@example.com', 1234),
 		(3, '', '', '', '', '', '', '', 1),

--- a/internal/testdata/schema.sql
+++ b/internal/testdata/schema.sql
@@ -281,11 +281,15 @@ WITH (
 )
 TABLESPACE pg_default;
 
--- Table: public.firm
+-- Table: supervision.firm
 
-DROP TABLE IF EXISTS public.firm;
+DROP TABLE IF EXISTS supervision.firm;
 
-CREATE TABLE public.firm
+DROP SCHEMA IF EXISTS supervision;
+
+CREATE SCHEMA supervision;
+
+CREATE TABLE supervision.firm
 (
     id integer NOT NULL,
     firmname character varying(255) NOT NULL,


### PR DESCRIPTION
This change only affects local builds, but does break them altogether.

Make the SQL for creating the test database and the db interfacing code use supervision.firm instead of just firm.