### PR TITLE
Turn off lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,6 @@
         "Dependencies",
         "Renovate"
     ],
-    "lockFileMaintenance": {
-        "enabled": true
-    },
     "packageRules": [
         {
             "automerge": true,


### PR DESCRIPTION
We agreed a while ago to stop creating lockfile maintenance PRs, because we generally have no need to keep transitive dependencies up-to-date. However, security patches will continue to be created.

#patch