### PR TITLE
Fix postgres to 13.12

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,22 @@
     ],
     "packageRules": [
         {
+            "description": [
+              "Docker Major Dependency Exclusions",
+              "postgres - Excluded from updates to allow us to match major versions to the deployed version in AWS"
+            ],
+            "matchUpdateTypes": [
+              "major"
+            ],
+            "matchDatasources": [
+              "docker"
+            ],
+            "matchPackageNames": [
+              "postgres"
+            ],
+            "enabled": false
+          },
+        {
             "automerge": true,
             "groupName": "Patch & Minor Updates",
             "groupSlug": "all-minor-patch-updates",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     command: golangci-lint run -v --timeout 5m
 
   postgres:
-    image: postgres:15.3
+    image: postgres:13.12
     ports: ["5434:5432"]
     command: postgres
     environment:


### PR DESCRIPTION
To match major versioning with what we have deployed in AWS (and in `opg-sirius`)

#patch