### PR TITLE
VEGA-2529 Improve alias parsing so it may contain underscores (like digital_lpa) #minor

### DIFF
--- a/internal/cmd/cleanup_indices.go
+++ b/internal/cmd/cleanup_indices.go
@@ -4,11 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"sort"
-	"strings"
-
-	"github.com/ministryofjustice/opg-search-service/internal/firm"
-	"github.com/ministryofjustice/opg-search-service/internal/person"
 	"github.com/sirupsen/logrus"
 )
 
@@ -18,25 +13,25 @@ type CleanupIndicesClient interface {
 	DeleteIndex(ctx context.Context, name string) error
 }
 
-type cleanupIndicesCommand struct {
+type CleanupIndicesCommand struct {
 	logger         *logrus.Logger
 	client         CleanupIndicesClient
-	currentIndices map[string][]byte
+	currentIndices []IndexConfig
 }
 
-func NewCleanupIndices(logger *logrus.Logger, client CleanupIndicesClient, indices map[string][]byte) *cleanupIndicesCommand {
-	return &cleanupIndicesCommand{
+func NewCleanupIndices(logger *logrus.Logger, client CleanupIndicesClient, currentIndices []IndexConfig) *CleanupIndicesCommand {
+	return &CleanupIndicesCommand{
 		logger:         logger,
 		client:         client,
-		currentIndices: indices,
+		currentIndices: currentIndices,
 	}
 }
 
-func (c *cleanupIndicesCommand) Info() (name, description string) {
+func (c *CleanupIndicesCommand) Info() (name, description string) {
 	return "cleanup-indices", "remove unused indices"
 }
 
-func (c *cleanupIndicesCommand) Run(args []string) error {
+func (c *CleanupIndicesCommand) Run(args []string) error {
 	ctx := context.Background()
 	flagset := flag.NewFlagSet("cleanup-indices", flag.ExitOnError)
 
@@ -46,42 +41,27 @@ func (c *cleanupIndicesCommand) Run(args []string) error {
 		return err
 	}
 
-	for _, aliasName := range []string{firm.AliasName, person.AliasName} {
-		aliasedIndex, err := c.client.ResolveAlias(ctx, aliasName)
-		if err != nil {
-			return err
-		}
-		if _, ok := c.currentIndices[aliasedIndex]; !ok {
-			return fmt.Errorf("alias '%s' is set to '%s' not a current index: %s", aliasName, aliasedIndex, mapKeys(c.currentIndices))
-		}
-
-		indices, err := c.client.Indices(ctx, aliasName+"_*")
+	for _, indexConfig := range c.currentIndices {
+		indices, err := c.client.Indices(ctx, indexConfig.Alias+"_*")
 		if err != nil {
 			return err
 		}
 
-		for _, index := range indices {
-			if _, ok := c.currentIndices[index]; !ok {
-				if *explain {
-					c.logger.Println("will delete", index)
-				} else {
-					if err := c.client.DeleteIndex(ctx, index); err != nil {
-						return err
-					}
+		for _, indexName := range indices {
+			if indexConfig.Name == indexName {
+				c.logger.Println(fmt.Sprintf("keeping index %s aliased as %s", indexName, indexConfig.Alias))
+				continue
+			}
+
+			if *explain {
+				c.logger.Println("will delete", indexName)
+			} else {
+				if err := c.client.DeleteIndex(ctx, indexName); err != nil {
+					return err
 				}
 			}
 		}
 	}
 
 	return nil
-}
-
-func mapKeys(m map[string][]byte) string {
-	var keys []string
-	for k := range m {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-	return strings.Join(keys, ", ")
 }

--- a/internal/cmd/cleanup_indices_test.go
+++ b/internal/cmd/cleanup_indices_test.go
@@ -56,32 +56,23 @@ func TestCleanupIndices(t *testing.T) {
 	client.On("DeleteIndex", mock.Anything, "firm_xyz").Return(nil).Once()
 	client.On("DeleteIndex", mock.Anything, "firm_abc").Return(nil).Once()
 
-	command := NewCleanupIndices(l, client, map[string][]byte{"firm_something": indexConfig, "person_something": indexConfig})
+	command := NewCleanupIndices(
+		l,
+		client,
+		[]IndexConfig{
+			{
+				Name:   "person_something",
+				Alias:  "person",
+				Config: indexConfig,
+			},
+			{
+				Name:   "firm_something",
+				Alias:  "firm",
+				Config: indexConfig,
+			},
+		},
+	)
 	assert.Nil(t, command.Run([]string{}))
-}
-
-func TestCleanupIndicesWhenAliasNotCurrent(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	client := &mockCleanupIndicesClient{}
-
-	client.
-		On("ResolveAlias", mock.Anything, person.AliasName).
-		Return("person_xyz", nil)
-
-	client.
-		On("ResolveAlias", mock.Anything, firm.AliasName).
-		Return("firm_xyz", nil)
-
-	client.
-		On("Indices", mock.Anything, "person_*").
-		Return([]string{"person_xyz", "person_something", "person_abc"}, nil)
-
-	client.
-		On("Indices", mock.Anything, "firm_*").
-		Return([]string{"firm_xyz", "firm_something", "firm_abc"}, nil)
-
-	command := NewCleanupIndices(l, client, map[string][]byte{"firm_something": indexConfig, "person_something": indexConfig})
-	assert.Equal(t, "alias 'firm' is set to 'firm_xyz' not a current index: firm_something, person_something", command.Run([]string{}).Error())
 }
 
 func TestCleanupIndicesExplain(t *testing.T) {

--- a/internal/cmd/create_indices_test.go
+++ b/internal/cmd/create_indices_test.go
@@ -46,7 +46,13 @@ func TestCreateIndicesRun(t *testing.T) {
 				esClient.On("ResolveAlias", mock.Anything, "person").Times(1).Return("", nil)
 			}
 
-			command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
+			command := NewCreateIndices(esClient, []IndexConfig{
+				{
+					Name:   "person_test",
+					Alias:  "person",
+					Config: indexConfig,
+				},
+			})
 
 			args := []string{}
 			if tc.force {
@@ -67,7 +73,13 @@ func TestCreateIndicesRunCreateAlias(t *testing.T) {
 		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
 		On("CreateAlias", mock.Anything, "person", "person_test").Times(1).Return(nil)
 
-	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
+	command := NewCreateIndices(esClient, []IndexConfig{
+		{
+			Name:   "person_test",
+			Alias:  "person",
+			Config: indexConfig,
+		},
+	})
 
 	args := []string{"-force"}
 
@@ -85,7 +97,13 @@ func TestCreateIndicesRunCreateAliasFails(t *testing.T) {
 		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", elasticsearch.ErrAliasMissing).
 		On("CreateAlias", mock.Anything, "person", "person_test").Times(1).Return(creationErr)
 
-	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
+	command := NewCreateIndices(esClient, []IndexConfig{
+		{
+			Name:   "person_test",
+			Alias:  "person",
+			Config: indexConfig,
+		},
+	})
 
 	args := []string{"-force"}
 
@@ -102,7 +120,13 @@ func TestCreateIndicesRunResolveAliasFails(t *testing.T) {
 		On("CreateIndex", mock.Anything, "person_test", indexConfig, true).Times(1).Return(nil).
 		On("ResolveAlias", mock.Anything, "person").Times(1).Return("", resolveErr)
 
-	command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
+	command := NewCreateIndices(esClient, []IndexConfig{
+		{
+			Name:   "person_test",
+			Alias:  "person",
+			Config: indexConfig,
+		},
+	})
 
 	args := []string{"-force"}
 
@@ -134,7 +158,13 @@ func TestCreateIndicesRunErrorInFirst(t *testing.T) {
 			esClient := new(elasticsearch.MockESClient)
 			esClient.On("CreateIndex", mock.Anything, "person_test", indexConfig, tc.force).Times(1).Return(tc.error)
 
-			command := NewCreateIndices(esClient, map[string][]byte{"person_test": indexConfig})
+			command := NewCreateIndices(esClient, []IndexConfig{
+				{
+					Name:   "person_test",
+					Alias:  "person",
+					Config: indexConfig,
+				},
+			})
 
 			args := []string{}
 			if tc.force {

--- a/internal/cmd/update_alias.go
+++ b/internal/cmd/update_alias.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,25 +11,25 @@ type UpdateAliasClient interface {
 	UpdateAlias(ctx context.Context, alias, oldIndex, newIndex string) error
 }
 
-type updateAliasCommand struct {
+type UpdateAliasCommand struct {
 	logger         *logrus.Logger
 	client         UpdateAliasClient
-	currentIndices map[string][]byte
+	currentIndices []IndexConfig
 }
 
-func NewUpdateAlias(logger *logrus.Logger, client UpdateAliasClient, indices map[string][]byte) *updateAliasCommand {
-	return &updateAliasCommand{
+func NewUpdateAlias(logger *logrus.Logger, client UpdateAliasClient, currentIndices []IndexConfig) *UpdateAliasCommand {
+	return &UpdateAliasCommand{
 		logger:         logger,
 		client:         client,
-		currentIndices: indices,
+		currentIndices: currentIndices,
 	}
 }
 
-func (c *updateAliasCommand) Info() (name, description string) {
+func (c *UpdateAliasCommand) Info() (name, description string) {
 	return "update-alias", "update aliases to refer to the current indices"
 }
 
-func (c *updateAliasCommand) Run(args []string) error {
+func (c *UpdateAliasCommand) Run(args []string) error {
 	ctx := context.Background()
 	flagset := flag.NewFlagSet("update-alias", flag.ExitOnError)
 
@@ -42,30 +39,21 @@ func (c *updateAliasCommand) Run(args []string) error {
 		return err
 	}
 
-	for indexName := range c.currentIndices {
-		// assumption is that the alias looks like <alias>_<hash>, where <hash> is appended by opensearch;
-		// <alias> may contain underscores, and we assume only the last _<hash> part can be discarded, with the
-		// remainder being the alias
-		aliasParts := strings.Split(indexName, "_")
-		if len(aliasParts) < 2 {
-			return errors.New("invalid index alias")
-		}
-		aliasName := strings.Join(aliasParts[0:len(aliasParts)-1], "_")
-
-		aliasedIndex, err := c.client.ResolveAlias(ctx, aliasName)
+	for _, indexConfig := range c.currentIndices {
+		currentAliasedIndex, err := c.client.ResolveAlias(ctx, indexConfig.Alias)
 		if err != nil {
 			return err
 		}
 
-		if aliasedIndex == indexName {
-			c.logger.Printf("alias '%s' is already set to '%s'", aliasName, indexName)
+		if currentAliasedIndex == indexConfig.Name {
+			c.logger.Printf("alias '%s' is already set to '%s'", indexConfig.Alias, indexConfig.Name)
 			continue
 		}
 
 		if *explain {
-			c.logger.Printf("will update alias '%s' to '%s'", aliasName, indexName)
+			c.logger.Printf("will update alias '%s' to '%s'", indexConfig.Alias, indexConfig.Name)
 		} else {
-			if err := c.client.UpdateAlias(ctx, aliasName, aliasedIndex, indexName); err != nil {
+			if err := c.client.UpdateAlias(ctx, indexConfig.Alias, currentAliasedIndex, indexConfig.Name); err != nil {
 				return err
 			}
 		}

--- a/internal/cmd/update_alias.go
+++ b/internal/cmd/update_alias.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"strings"
 
@@ -42,7 +43,14 @@ func (c *updateAliasCommand) Run(args []string) error {
 	}
 
 	for indexName := range c.currentIndices {
-		aliasName := strings.Split(indexName, "_")[0]
+		// assumption is that the alias looks like <alias>_<hash>, where <hash> is appended by opensearch;
+		// <alias> may contain underscores, and we assume only the last _<hash> part can be discarded, with the
+		// remainder being the alias
+		aliasParts := strings.Split(indexName, "_")
+		if len(aliasParts) < 2 {
+			return errors.New("invalid index alias")
+		}
+		aliasName := strings.Join(aliasParts[0:len(aliasParts)-1], "_")
 
 		aliasedIndex, err := c.client.ResolveAlias(ctx, aliasName)
 		if err != nil {

--- a/internal/cmd/update_alias_test.go
+++ b/internal/cmd/update_alias_test.go
@@ -39,7 +39,13 @@ func TestUpdatePersonAlias(t *testing.T) {
 		On("UpdateAlias", mock.Anything, person.AliasName, "person_old", "person_expected").
 		Return(nil)
 
-	command := NewUpdateAlias(l, client, map[string][]byte{"person_expected": indexConfig})
+	command := NewUpdateAlias(l, client, []IndexConfig{
+		{
+			Name:   "person_expected",
+			Alias:  "person",
+			Config: indexConfig,
+		},
+	})
 	assert.Nil(t, command.Run([]string{}))
 }
 
@@ -55,7 +61,13 @@ func TestUpdateFirmAlias(t *testing.T) {
 		On("UpdateAlias", mock.Anything, firm.AliasName, "firm_old", "firm_expected").
 		Return(nil)
 
-	command := NewUpdateAlias(l, client, map[string][]byte{"firm_expected": indexConfig})
+	command := NewUpdateAlias(l, client, []IndexConfig{
+		{
+			Name:   "firm_expected",
+			Alias:  "firm",
+			Config: indexConfig,
+		},
+	})
 	assert.Nil(t, command.Run([]string{}))
 }
 
@@ -67,7 +79,13 @@ func TestUpdatePersonAliasWhenAliasIsCurrent(t *testing.T) {
 		On("ResolveAlias", mock.Anything, person.AliasName).
 		Return("person_expected", nil)
 
-	command := NewUpdateAlias(l, client, map[string][]byte{"person_expected": indexConfig})
+	command := NewUpdateAlias(l, client, []IndexConfig{
+		{
+			Name:   "person_expected",
+			Alias:  "person",
+			Config: indexConfig,
+		},
+	})
 	assert.Nil(t, command.Run([]string{}))
 
 	assert.Equal(t, "alias 'person' is already set to 'person_expected'", hook.LastEntry().Message)
@@ -81,7 +99,13 @@ func TestUpdateFirmAliasWhenAliasIsCurrent(t *testing.T) {
 		On("ResolveAlias", mock.Anything, firm.AliasName).
 		Return("firm_expected", nil)
 
-	command := NewUpdateAlias(l, client, map[string][]byte{"firm_expected": indexConfig})
+	command := NewUpdateAlias(l, client, []IndexConfig{
+		{
+			Name:   "firm_expected",
+			Alias:  "firm",
+			Config: indexConfig,
+		},
+	})
 	assert.Nil(t, command.Run([]string{}))
 
 	assert.Equal(t, "alias 'firm' is already set to 'firm_expected'", hook.LastEntry().Message)
@@ -90,17 +114,23 @@ func TestUpdateFirmAliasWhenAliasIsCurrent(t *testing.T) {
 func TestUpdateDigitalLpaAlias(t *testing.T) {
 	l, _ := test.NewNullLogger()
 	client := &mockUpdateAliasClient{}
-	oldAlias := fmt.Sprintf("%s_1a2b3c4d", digitallpa.AliasName)
-	newAlias := fmt.Sprintf("%s_0z9y8x7w", digitallpa.AliasName)
+	oldAliasedIndex := fmt.Sprintf("%s_1a2b3c4d", digitallpa.AliasName)
+	newAliasedIndex := fmt.Sprintf("%s_0z9y8x7w", digitallpa.AliasName)
 
 	client.
 		On("ResolveAlias", mock.Anything, digitallpa.AliasName).
-		Return(oldAlias, nil)
+		Return(oldAliasedIndex, nil)
 
 	client.
-		On("UpdateAlias", mock.Anything, digitallpa.AliasName, oldAlias, newAlias).
+		On("UpdateAlias", mock.Anything, digitallpa.AliasName, oldAliasedIndex, newAliasedIndex).
 		Return(nil)
 
-	command := NewUpdateAlias(l, client, map[string][]byte{newAlias: indexConfig})
+	command := NewUpdateAlias(l, client, []IndexConfig{
+		{
+			Name:   "digital_lpa_1a2b3c4d",
+			Alias:  "digital_lpa",
+			Config: indexConfig,
+		},
+	})
 	assert.Nil(t, command.Run([]string{}))
 }

--- a/internal/cmd/update_alias_test.go
+++ b/internal/cmd/update_alias_test.go
@@ -104,11 +104,3 @@ func TestUpdateDigitalLpaAlias(t *testing.T) {
 	command := NewUpdateAlias(l, client, map[string][]byte{newAlias: indexConfig})
 	assert.Nil(t, command.Run([]string{}))
 }
-
-func TestUpdateDigitalLpaAliasWhenAliasIsBad(t *testing.T) {
-	l, _ := test.NewNullLogger()
-	client := &mockUpdateAliasClient{}
-
-	command := NewUpdateAlias(l, client, map[string][]byte{"a": indexConfig})
-	assert.NotNil(t, command.Run([]string{}))
-}

--- a/internal/cmd/update_alias_test.go
+++ b/internal/cmd/update_alias_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"github.com/ministryofjustice/opg-search-service/internal/digitallpa"
 	"testing"
 
 	"github.com/ministryofjustice/opg-search-service/internal/firm"
@@ -83,4 +85,30 @@ func TestUpdateFirmAliasWhenAliasIsCurrent(t *testing.T) {
 	assert.Nil(t, command.Run([]string{}))
 
 	assert.Equal(t, "alias 'firm' is already set to 'firm_expected'", hook.LastEntry().Message)
+}
+
+func TestUpdateDigitalLpaAlias(t *testing.T) {
+	l, _ := test.NewNullLogger()
+	client := &mockUpdateAliasClient{}
+	oldAlias := fmt.Sprintf("%s_1a2b3c4d", digitallpa.AliasName)
+	newAlias := fmt.Sprintf("%s_0z9y8x7w", digitallpa.AliasName)
+
+	client.
+		On("ResolveAlias", mock.Anything, digitallpa.AliasName).
+		Return(oldAlias, nil)
+
+	client.
+		On("UpdateAlias", mock.Anything, digitallpa.AliasName, oldAlias, newAlias).
+		Return(nil)
+
+	command := NewUpdateAlias(l, client, map[string][]byte{newAlias: indexConfig})
+	assert.Nil(t, command.Run([]string{}))
+}
+
+func TestUpdateDigitalLpaAliasWhenAliasIsBad(t *testing.T) {
+	l, _ := test.NewNullLogger()
+	client := &mockUpdateAliasClient{}
+
+	command := NewUpdateAlias(l, client, map[string][]byte{"a": indexConfig})
+	assert.NotNil(t, command.Run([]string{}))
 }

--- a/internal/digitallpa/digital_lpa.go
+++ b/internal/digitallpa/digital_lpa.go
@@ -1,9 +1,7 @@
 package digitallpa
 
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"github.com/ministryofjustice/opg-search-service/internal/response"
 )
 
@@ -57,7 +55,7 @@ func (d DigitalLpa) Validate() []response.Error {
 	return errs
 }
 
-func IndexConfig() (name string, config []byte, err error) {
+func IndexConfig() (config []byte, err error) {
 	textField := map[string]interface{}{"type": "text"}
 	searchableTextField := map[string]interface{}{"type": "text", "copy_to": "searchable"}
 	keywordField := map[string]interface{}{"type": "keyword"}
@@ -163,10 +161,8 @@ func IndexConfig() (name string, config []byte, err error) {
 
 	data, err := json.Marshal(digitalLpaConfig)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	sum := sha256.Sum256(data)
-
-	return fmt.Sprintf("%s_%x", AliasName, sum[:8]), data, err
+	return data, err
 }

--- a/internal/digitallpa/digital_lpa_test.go
+++ b/internal/digitallpa/digital_lpa_test.go
@@ -65,7 +65,6 @@ func TestDigitalLpa_Validate(t *testing.T) {
 }
 
 func TestDigitalLpa_IndexConfig(t *testing.T) {
-	name, _, err := IndexConfig()
+	_, err := IndexConfig()
 	assert.Nil(t, err)
-	assert.Regexp(t, `[a-z]+_[a-z0-9]+`, name)
 }

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -52,7 +52,7 @@ type elasticSearchResponse struct {
 			Relation string `json:"relation"`
 		} `json:"total"`
 		Hits []struct {
-			Index  string          `json:"_index"`
+			Index  string                 `json:"_index"`
 			Source map[string]interface{} `json:"_source"`
 		} `json:"hits"`
 	} `json:"hits"`
@@ -301,6 +301,7 @@ func (c *Client) Search(ctx context.Context, indices []string, requestBody map[s
 }
 
 func (c *Client) CreateIndex(ctx context.Context, name string, config []byte, force bool) error {
+	c.logger.Printf("Checking index '%s' exists", name)
 	exists, err := c.IndexExists(ctx, name)
 	if err != nil {
 		return err
@@ -330,8 +331,6 @@ func (c *Client) CreateIndex(ctx context.Context, name string, config []byte, fo
 }
 
 func (c *Client) IndexExists(ctx context.Context, name string) (bool, error) {
-	c.logger.Printf("Checking index '%s' exists", name)
-
 	resp, err := c.doRequest(ctx, http.MethodHead, name, nil, "")
 	if err != nil {
 		return false, err

--- a/internal/firm/firm.go
+++ b/internal/firm/firm.go
@@ -1,9 +1,7 @@
 package firm
 
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/ministryofjustice/opg-search-service/internal/response"
@@ -47,7 +45,7 @@ func (f Firm) Validate() []response.Error {
 	return errs
 }
 
-func IndexConfig() (name string, config []byte, err error) {
+func IndexConfig() (config []byte, err error) {
 	firmConfig := map[string]interface{}{
 		"settings": map[string]interface{}{
 			"number_of_shards":   3,
@@ -95,10 +93,8 @@ func IndexConfig() (name string, config []byte, err error) {
 
 	data, err := json.Marshal(firmConfig)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	sum := sha256.Sum256(data)
-
-	return fmt.Sprintf("%s_%x", AliasName, sum[:8]), data, err
+	return data, err
 }

--- a/internal/firm/firm_test.go
+++ b/internal/firm/firm_test.go
@@ -79,8 +79,6 @@ func TestFirm_Validate(t *testing.T) {
 }
 
 func TestFirm_IndexConfig(t *testing.T) {
-	name, _, err := IndexConfig()
-
+	_, err := IndexConfig()
 	assert.Nil(t, err)
-	assert.Regexp(t, `[a-z]+_[a-z0-9]+`, name)
 }

--- a/internal/person/db_test.go
+++ b/internal/person/db_test.go
@@ -333,16 +333,16 @@ func TestQueryFromDate(t *testing.T) {
 }
 
 func TestGetAddressLinesHandlesEmptyValues(t *testing.T) {
-	address := getAddressLines([]interface{}{"123 Test Street", "Footown", nil,})
+	address := getAddressLines([]interface{}{"123 Test Street", "Footown", nil})
 	assert.Equal(t, []string{"123 Test Street", "Footown"}, address)
 
 	// note that although we shouldn't get more than 3 address lines,
 	// this case checks that we cope correctly if we do for some reason
 	address = getAddressLines(map[string]interface{}{
-		"2": "",
-		"3": "Footown",
-		"1": "123 Test Street",
-		"4": nil,
+		"2":      "",
+		"3":      "Footown",
+		"1":      "123 Test Street",
+		"4":      nil,
 		"random": "nonsense",
 	})
 	assert.Equal(t, []string{"123 Test Street", "Footown"}, address)

--- a/internal/person/person.go
+++ b/internal/person/person.go
@@ -1,9 +1,7 @@
 package person
 
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/ministryofjustice/opg-search-service/internal/response"
@@ -73,7 +71,7 @@ func (p Person) Validate() []response.Error {
 	return errs
 }
 
-func IndexConfig() (name string, config []byte, err error) {
+func IndexConfig() (config []byte, err error) {
 	textField := map[string]interface{}{"type": "text"}
 	searchableTextField := map[string]interface{}{"type": "text", "copy_to": "searchable"}
 	keywordField := map[string]interface{}{"type": "keyword"}
@@ -161,10 +159,8 @@ func IndexConfig() (name string, config []byte, err error) {
 
 	data, err := json.Marshal(personConfig)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	sum := sha256.Sum256(data)
-
-	return fmt.Sprintf("%s_%x", AliasName, sum[:8]), data, err
+	return data, err
 }

--- a/internal/person/person_test.go
+++ b/internal/person/person_test.go
@@ -79,8 +79,6 @@ func TestPerson_Validate(t *testing.T) {
 }
 
 func TestPerson_IndexConfig(t *testing.T) {
-	name, _, err := IndexConfig()
-
+	_, err := IndexConfig()
 	assert.Nil(t, err)
-	assert.Regexp(t, `[a-z]+_[a-z0-9]+`, name)
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -23,22 +21,6 @@ import (
 	"github.com/ministryofjustice/opg-search-service/internal/search"
 	"github.com/sirupsen/logrus"
 )
-
-func buildIndexConfig(configFunc func() (config []byte, err error), alias string, l *logrus.Logger) cmd.IndexConfig {
-	config, err := configFunc()
-	if err != nil {
-		l.Fatal(err)
-	}
-
-	sum := sha256.Sum256(config)
-	indexName := fmt.Sprintf("%s_%x", alias, sum[:8])
-
-	return cmd.IndexConfig{
-		Name:   indexName,
-		Alias:  alias,
-		Config: config,
-	}
-}
 
 func createIndexAndAlias(esClient *elasticsearch.Client, indexConfig cmd.IndexConfig, l *logrus.Logger) []string {
 	ctx := context.Background()
@@ -71,9 +53,9 @@ func main() {
 	l.SetFormatter(&logrus.JSONFormatter{})
 
 	// create indices for entities
-	personIndexConfig := buildIndexConfig(person.IndexConfig, person.AliasName, l)
-	firmIndexConfig := buildIndexConfig(firm.IndexConfig, firm.AliasName, l)
-	digitallpaIndexConfig := buildIndexConfig(digitallpa.IndexConfig, digitallpa.AliasName, l)
+	personIndexConfig := cmd.NewIndexConfig(person.IndexConfig, person.AliasName, l)
+	firmIndexConfig := cmd.NewIndexConfig(firm.IndexConfig, firm.AliasName, l)
+	digitallpaIndexConfig := cmd.NewIndexConfig(digitallpa.IndexConfig, digitallpa.AliasName, l)
 
 	currentIndices := []cmd.IndexConfig{
 		personIndexConfig,

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ministryofjustice/opg-search-service/internal/cmd"
 	"io/ioutil"
 	"log"
 	"net"
@@ -160,15 +161,15 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 	suite.Nil(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
 
-	indexName, _, _ := person.IndexConfig()
-	indexNameFirm, _, _ := firm.IndexConfig()
+	personIndexConfig := cmd.NewIndexConfig(person.IndexConfig, person.AliasName, logger)
+	firmIndexConfig := cmd.NewIndexConfig(firm.IndexConfig, firm.AliasName, logger)
 	ctx := context.Background()
 
-	exists, err := suite.esClient.IndexExists(ctx, indexName)
+	exists, err := suite.esClient.IndexExists(ctx, personIndexConfig.Name)
 	suite.False(exists, "Person index should not exist at this point")
 	suite.Nil(err)
 
-	existsFirmIndex, err := suite.esClient.IndexExists(ctx, indexNameFirm)
+	existsFirmIndex, err := suite.esClient.IndexExists(ctx, firmIndexConfig.Name)
 	suite.False(existsFirmIndex, "Firm index should not exist at this point")
 	suite.Nil(err)
 
@@ -181,11 +182,11 @@ func (suite *EndToEndTestSuite) SetupSuite() {
 			continue
 		}
 
-		exists, err = suite.esClient.IndexExists(ctx, indexName)
+		exists, err = suite.esClient.IndexExists(ctx, personIndexConfig.Name)
 		suite.True(exists, "Person index should exist at this point")
 		suite.Nil(err)
 
-		existsFirmIndex, err = suite.esClient.IndexExists(ctx, indexNameFirm)
+		existsFirmIndex, err = suite.esClient.IndexExists(ctx, firmIndexConfig.Name)
 		suite.True(existsFirmIndex, "Firm index should exist at this point")
 		suite.Nil(err)
 


### PR DESCRIPTION
The idea is that the alias for an index and the real name of the index are held together, so we don't have to guess the alias from the real name at any point. This generally makes managing indices cleaner, too, as we are passing fewer arguments around.