### PR TITLE
VEGA-4001 search tiebreaker bugfix

### DIFF
--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -135,6 +135,10 @@ func withDefaults(req *Request, body map[string]interface{}) map[string]interfac
 	}
 	body["from"] = req.From
 	body["post_filter"] = map[string]interface{}{"bool": map[string]interface{}{"should": filters}}
+	body["sort"] = []interface{}{
+		map[string]interface{}{"_score": "desc"},
+		map[string]interface{}{"_id": "asc"},
+	}
 	if req.Size > 0 {
 		body["size"] = req.Size
 	}

--- a/internal/search/query_test.go
+++ b/internal/search/query_test.go
@@ -1,8 +1,9 @@
 package search
 
 import (
-	"github.com/ministryofjustice/opg-search-service/internal/digitallpa"
 	"testing"
+
+	"github.com/ministryofjustice/opg-search-service/internal/digitallpa"
 
 	"github.com/stretchr/testify/assert"
 
@@ -34,7 +35,11 @@ func TestPrepareQueryForFirm(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 123,
 	}, body)
 
 	assert.Equal(t, []string{firm.AliasName}, indices)
@@ -69,6 +74,10 @@ func TestPrepareQueryForFirmWithOptions(t *testing.T) {
 			map[string]interface{}{"term": map[string]string{"personType": "deputy"}},
 			map[string]interface{}{"term": map[string]string{"personType": "donor"}},
 		}}},
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
 		"from": 123,
 		"size": 10,
 	}, body)
@@ -108,7 +117,11 @@ func TestPrepareQueryForPerson(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 123,
 	}, body)
 
 	assert.Equal(t, []string{person.AliasName}, indices)
@@ -151,6 +164,10 @@ func TestPrepareQueryForPersonWithOptions(t *testing.T) {
 			map[string]interface{}{"term": map[string]string{"personType": "deputy"}},
 			map[string]interface{}{"term": map[string]string{"personType": "donor"}},
 		}}},
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
 		"from": 123,
 		"size": 10,
 	}, body)
@@ -189,7 +206,11 @@ func TestPrepareQueryForDigitalLpa(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 123,
 	}, body)
 
 	assert.Equal(t, []string{digitallpa.AliasName}, indices)
@@ -242,7 +263,11 @@ func TestPrepareQueryForDeputy(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        9,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 9,
 	}, body)
 
 	assert.Equal(t, []string{person.AliasName}, indices)
@@ -272,7 +297,11 @@ func TestPrepareQueryForAll(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 123,
 	}, body)
 
 	assert.Equal(t, []string{firm.AliasName, person.AliasName, digitallpa.AliasName}, indices)
@@ -303,7 +332,11 @@ func TestPrepareQueryForAllEmptyIndices(t *testing.T) {
 			},
 		},
 		"post_filter": map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{}}},
-		"from":        123,
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
+		"from": 123,
 	}, body)
 
 	assert.Equal(t, []string{firm.AliasName, person.AliasName, digitallpa.AliasName}, indices)
@@ -339,6 +372,10 @@ func TestPrepareQueryForAllWithOptions(t *testing.T) {
 			map[string]interface{}{"term": map[string]string{"personType": "deputy"}},
 			map[string]interface{}{"term": map[string]string{"personType": "donor"}},
 		}}},
+		"sort": []interface{}{
+			map[string]interface{}{"_score": "desc"},
+			map[string]interface{}{"_id": "asc"},
+		},
 		"from": 123,
 		"size": 10,
 	}, body)


### PR DESCRIPTION
[VEGA-4001
](https://opgtransform.atlassian.net/browse/VEGA-4001)
### Problem

QA reported search results duplicating across pages and reordering when navigating back and forth between pages (e.g. searching `TRCK0016165139`, filtering by Donor, the two cases for `KO` would sometimes duplicate on page 2 or change order/count when returning to page 1).

### Root cause

`withDefaults` in `query.go` builds the OpenSearch query body for all non-`prepared` search paths (person, deputy, firm, digitalLpa, all) but never sets a `sort` clause. Without one, OpenSearch falls back to `_score` relevance ranking alone. Where two documents tie on score (e.g. two cases belonging to the same donor for an identical search term), OpenSearch doesn't guarantee a stable relative order for ties across separate query executions — order can shift between requests depending on which shard/replica serves it. Combined with offset-based (`from`/`size`) pagination, this produces exactly the reported symptoms: a tied record can land on either side of the page boundary on different requests, causing duplicates on one page and reordering when navigating back.

### Fix

Added an explicit `sort` to `withDefaults`:

```go
body["sort"] = []interface{}{
    map[string]interface{}{"_score": "desc"},
    map[string]interface{}{"_id": "asc"},
}
```

`_score desc` preserves existing relevance-first ordering (no behaviour change to primary ordering). `_id asc` is the tiebreaker — sorting on the document's built-in `_id` rather than a named field (e.g. `uId`) avoids `query_shard_exception` on indices (e.g. `firm`) that don't have that field mapped, since `_id` exists on every document across every index without requiring explicit mapping.

### Scope

Affects all query builders routed through `withDefaults`: `PrepareQueryForPerson`, `PrepareQueryForDeputy`, `PrepareQueryForFirm`, `PrepareQueryForDigitalLpa`, `PrepareQueryForAll`.

**Not in scope:** the legacy Angular client's `prepared` query path (`APIV1Search.defaultSearch`) bypasses `withDefaults` entirely and has its own separate `sort: { surname: asc }` with no tiebreaker — same underlying issue, different code path. Raising as a follow-up ticket rather than fixing here.

### Testing

- Unit tests in `query_test.go` updated to expect the new `sort` key across all affected cases
- To be verified in Adhoc against real/prod-like data before merge — comparing the known case (→ Donor filter → `KO` cases) plus a spread of other search terms across person/deputy/firm/all, to rule out unexpected side effects (per past experience with search changes having non-obvious knock-on effects, e.g. the postcode-prioritisation issue)